### PR TITLE
change 2.0.4 version 

### DIFF
--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -8,15 +8,13 @@ on:
 
 jobs:
   dotnet-format:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 8.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+	<PropertyGroup>
+		<NoWarn>NU1803;CS1591;CS0108;</NoWarn>
+	</PropertyGroup>
+	
+	<ItemGroup>
+		<InternalsVisibleTo Include="$(AssemblyName).Tests" />
+	</ItemGroup >
+</Project>

--- a/Luck.sln
+++ b/Luck.sln
@@ -31,6 +31,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "0.Solution Items", "0.Solut
 	ProjectSection(SolutionItems) = preProject
 		src\common.props = src\common.props
 		README.md = README.md
+		Directory.Build.props = Directory.Build.props
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Luck.EventBus.RabbitMQ", "src\framework\Luck.EventBus.RabbitMQ\Luck.EventBus.RabbitMQ.csproj", "{79FEBCDD-AED6-4FEA-AD14-EF34DDE22905}"

--- a/Luck.sln
+++ b/Luck.sln
@@ -32,6 +32,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "0.Solution Items", "0.Solut
 		src\common.props = src\common.props
 		README.md = README.md
 		Directory.Build.props = Directory.Build.props
+		.github\workflows\dotnet-format.yml = .github\workflows\dotnet-format.yml
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Luck.EventBus.RabbitMQ", "src\framework\Luck.EventBus.RabbitMQ\Luck.EventBus.RabbitMQ.csproj", "{79FEBCDD-AED6-4FEA-AD14-EF34DDE22905}"

--- a/Luck.sln
+++ b/Luck.sln
@@ -71,6 +71,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Luck.AutoDependencyInjectio
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Luck.EventBus.Kafka", "src\framework\Luck.EventBus.Kafka\Luck.EventBus.Kafka.csproj", "{9876D845-5C04-4B04-84A0-A57148253666}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Luck.EntityFrameworkCore.MemoryDataBase", "src\framework\Luck.EntityFrameworkCore.MemoryDataBase\Luck.EntityFrameworkCore.MemoryDataBase.csproj", "{F9E8F6FF-B571-4EFB-A06D-2201236D9B07}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -153,6 +155,10 @@ Global
 		{9876D845-5C04-4B04-84A0-A57148253666}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9876D845-5C04-4B04-84A0-A57148253666}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9876D845-5C04-4B04-84A0-A57148253666}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F9E8F6FF-B571-4EFB-A06D-2201236D9B07}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F9E8F6FF-B571-4EFB-A06D-2201236D9B07}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F9E8F6FF-B571-4EFB-A06D-2201236D9B07}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F9E8F6FF-B571-4EFB-A06D-2201236D9B07}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -185,6 +191,7 @@ Global
 		{CD68536D-E0DF-44E0-9243-14E9A44DCF07} = {DE49CCE6-B41E-493A-ADCC-EA6075DD0038}
 		{404C5BB1-243A-4BB8-8FFF-740A2A5A1F5C} = {DE49CCE6-B41E-493A-ADCC-EA6075DD0038}
 		{9876D845-5C04-4B04-84A0-A57148253666} = {5779CF18-7FD7-434D-B47A-1C8A50A3E5A4}
+		{F9E8F6FF-B571-4EFB-A06D-2201236D9B07} = {91CD3C81-AA29-47C7-B654-901872880B63}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {4719568B-E10A-4815-AAAA-8C6D6CEE798F}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,41 @@
 # Luck.Framework
++ ## change 2.0.4 version
+  + ### update
+    + **1、Luck.Framework支持Net7.0和8.0**
+    + **2、Luck.DDD.Domain支持Net7.0和8.0**
+    + **3、Luck.AspNetCore支持Net7.0和8.0**
+    ```c#
+        <ItemGroup Condition="$(TargetFramework) == 'net6.0'">
+          <FrameworkReference Include="Microsoft.AspNetCore.App" />
+        </ItemGroup>
+        <ItemGroup Condition="$(TargetFramework) == 'net7.0'">
+            <FrameworkReference Include="Microsoft.AspNetCore.App" />
+        </ItemGroup>
+        <ItemGroup Condition="$(TargetFramework) == 'net8.0'">
+            <FrameworkReference Include="Microsoft.AspNetCore.App" />
+        </ItemGroup>
+      ```
+    + **4、Luck.AppModule支持Net7.0和8.0**
+    + **5、Luck.AutoDependencyInjection支持Net7.0和8.0；移动模块化扩展方法到Luck.AutoDependencyInjection类库**
+    + **6、Luck.MongoDB支持Net7.0和8.0**
+    + **7、Luck.EntityFrameworkCore支持EFCore7.0he 8.0**
+    + **8、Luck.EntityFrameworkCore.MySQL；升级6.0的nuget包版本**
+    + **9、Luck.EntityFrameworkCore.PostGreSQL支持Net7.0和8.0；升级6.0的nuget包版本**
+    + **10、Luck.Dapper支持Net7.0和8.0;**
+    + **11、Luck.Dapper.ClickHouse支持Net7.0和8.0**
+    + **12、Luck.EventBus.RabbitMQ支持Net7.0和8.0；升级Polly和RabbitMQ.Client版本；通过一下代码导入需要Hosting等组件，不在单独引入包**
+    ```c#
+        <ItemGroup Condition="$(TargetFramework) == 'net6.0'">
+          <FrameworkReference Include="Microsoft.AspNetCore.App" />
+        </ItemGroup>
+        <ItemGroup Condition="$(TargetFramework) == 'net7.0'">
+            <FrameworkReference Include="Microsoft.AspNetCore.App" />
+        </ItemGroup>
+        <ItemGroup Condition="$(TargetFramework) == 'net8.0'">
+            <FrameworkReference Include="Microsoft.AspNetCore.App" />
+        </ItemGroup>
+      ```
+    + **13、Luck.Redis.StackExchange支持Net7.0和8.0；升级6.0的nuget包版本**
 + ## change 2.0.3 version
   + ### update
     + **1、Luck.Framework内的System.Text.Json自定义序列化删除，迁移到Luck.AspNetCore**

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Luck.Framework
-+ ## change 2.0.4 version
++ ## change 2.0.4 version 
+  + ### add
+    + **1、Luck.EntityFrameworkCore.MemoryDataBase**
   + ### update
     + **1、Luck.Framework支持Net7.0和8.0**
     + **2、Luck.DDD.Domain支持Net7.0和8.0**

--- a/sample/Module.Sample/AppModules/EntityFrameworkCoreModule.cs
+++ b/sample/Module.Sample/AppModules/EntityFrameworkCoreModule.cs
@@ -1,5 +1,6 @@
 ﻿using Luck.EntityFrameworkCore;
 using Luck.EntityFrameworkCore.DbContextDrivenProvides;
+using Luck.EntityFrameworkCore.PostgreSQL;
 using Module.Sample.DbContexts;
 
 namespace Module.Sample
@@ -12,7 +13,7 @@ namespace Module.Sample
             {
                 x.ConnectionString =
                     "User ID=postgres;Password=wzw0126..;Host=39.101.165.187;Port=8832;Database=module.test";
-                x.Type = DataBaseType.PostgreSQL;
+                x.Type = DataBaseType.PostgreSql;
             });
         }
 

--- a/sample/Module.Sample/Program.cs
+++ b/sample/Module.Sample/Program.cs
@@ -2,6 +2,7 @@ using Luck.AppModule;
 using Luck.AutoDependencyInjection.PropertyInjection;
 using Module.Sample;
 using System.Diagnostics;
+using Luck.AutoDependencyInjection;
 
 
 var builder = WebApplication.CreateBuilder(args);
@@ -14,7 +15,7 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 builder.Services.AddHttpContextAccessor();
 
-//Ìí¼ÓÕâ¸ö¡£
+//ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
 builder.Host.UsePropertyInjection();
 // builder.Services.AddDoveLogger();
 

--- a/src/common.props
+++ b/src/common.props
@@ -2,7 +2,7 @@
 	<PropertyGroup>
 		<LangVersion>latest</LangVersion>
 		<Version>2.0.3</Version>
-		<NoWarn>$(NoWarn);CS1591;CS0436</NoWarn>
+		<NoWarn>$(NoWarn);CS1591;CS0436;NU5104</NoWarn>
 		<PackageLicenseExpression>LGPL-3.0-only</PackageLicenseExpression>
 		<RepositoryType>git</RepositoryType>
 		<Authors>GeorGeWzw</Authors>
@@ -15,7 +15,13 @@
 		<!-- Include symbol files (*.pdb) in the built .nupkg -->
 		<AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 	</PropertyGroup>
-
+	
+	<PropertyGroup>
+		<TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+		<LangVersion>preview</LangVersion>
+		<Nullable>enable</Nullable>
+		<ImplicitUsings>enable</ImplicitUsings>
+	</PropertyGroup>
 	<ItemGroup>
 		<!-- <None Include="..\logo.jpg">
       <Pack>True</Pack>

--- a/src/common.props
+++ b/src/common.props
@@ -1,14 +1,14 @@
 ﻿<Project>
 	<PropertyGroup>
 		<LangVersion>latest</LangVersion>
-		<Version>2.0.3</Version>
+		<Version>2.0.4</Version>
 		<NoWarn>$(NoWarn);CS1591;CS0436;NU5104</NoWarn>
 		<PackageLicenseExpression>LGPL-3.0-only</PackageLicenseExpression>
 		<RepositoryType>git</RepositoryType>
-		<Authors>GeorGeWzw</Authors>
-		<Product>GeorGeWzw</Product>
-		<PackageProjectUrl>https://github.com/GeorGeWzw/Luck.Framework</PackageProjectUrl>
-		<RepositoryUrl>https://github.com/GeorGeWzw/Luck.Framework</RepositoryUrl>
+		<Authors>KawhiWei</Authors>
+		<Product>KawhiWei</Product>
+		<PackageProjectUrl>https://github.com/KawhiWei/Luck.Framework</PackageProjectUrl>
+		<RepositoryUrl>https://github.com/KawhiWei/Luck.Framework</RepositoryUrl>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<IsPackable>true</IsPackable>
 		<!-- <PackageIcon>logo.jpg</PackageIcon> -->

--- a/src/framework/Luck.AppModule/Luck.AppModule.csproj
+++ b/src/framework/Luck.AppModule/Luck.AppModule.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\common.props" />
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/framework/Luck.AppModule/Luck.AppModule.csproj
+++ b/src/framework/Luck.AppModule/Luck.AppModule.csproj
@@ -5,11 +5,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Luck.Framework\Luck.Framework.csproj" />
   </ItemGroup>

--- a/src/framework/Luck.AppModule/ModuleApplicationBase.cs
+++ b/src/framework/Luck.AppModule/ModuleApplicationBase.cs
@@ -13,6 +13,49 @@ namespace Luck.AppModule
         /// <summary>
         /// 
         /// </summary>
+        /// <param name="startupModuleType"></param>
+        /// <param name="services"></param>
+        protected ModuleApplicationBase(Type startupModuleType, IServiceCollection services)
+        {
+            ServiceProvider = null;
+            StartupModuleType = startupModuleType;
+            Services = services;
+            _ = services.AddSingleton<IModuleApplication>(this);
+            _ = services.TryAddObjectAccessor<IServiceProvider>();
+            Source = GetEnabledAllModule(services);
+            Modules = LoadModules;
+        }
+
+        /// <summary>
+        /// 获取所有需要加载的模块
+        /// </summary>
+        /// <exception cref="Exception"></exception>
+        private IReadOnlyList<IAppModule> LoadModules
+        {
+            get
+            {
+                var modules = new List<IAppModule>();
+                var module = Source.FirstOrDefault(o => o.GetType() == StartupModuleType);
+                if (module == null)
+                {
+                    throw new Exception($"类型为“{StartupModuleType.FullName}”的模块实例无法找到");
+                }
+
+                modules.Add(module);
+                var dependedTypes = module.GetDependedTypes();
+                foreach (var dependType in dependedTypes.Where(LuckAppModule.IsAppModule))
+                {
+                    var dependModule = Source.FirstOrDefault(o => o.GetType() == StartupModuleType) ?? throw new($"加载模块{module.GetType().FullName}时无法找到依赖模块{dependType.FullName}");
+                    modules.AddIfNotContains(dependModule);
+                }
+
+                return modules;
+            }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
         public Type StartupModuleType { get; set; }
 
         /// <summary>
@@ -21,9 +64,9 @@ namespace Luck.AppModule
         public IServiceCollection Services { get; set; }
 
         /// <summary>
-        /// 
+        /// IServiceProvider?
         /// </summary>
-        public IServiceProvider ServiceProvider { get; set; }
+        public IServiceProvider? ServiceProvider { get; private set; }
 
         /// <summary>
         /// 模块接口容器
@@ -33,23 +76,7 @@ namespace Luck.AppModule
         /// <summary>
         /// 
         /// </summary>
-        public List<IAppModule> Source { get; protected set; }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="startupModuleType"></param>
-        /// <param name="services"></param>
-        protected ModuleApplicationBase(Type startupModuleType, IServiceCollection services)
-        {
-            StartupModuleType = startupModuleType;
-            Services = services;
-
-            services.AddSingleton<IModuleApplication>(this);
-            services.TryAddObjectAccessor<IServiceProvider>();
-            Source = this.GetAllModule(services);
-            Modules = this.LoadModules();
-        }
+        public IEnumerable<IAppModule> Source { get; }
 
 
         /// <summary>
@@ -57,11 +84,11 @@ namespace Luck.AppModule
         /// </summary>
         /// <param name="services"></param>
         /// <returns></returns>
-        protected virtual List<IAppModule> GetAllModule(IServiceCollection services)
+        private static IEnumerable<IAppModule> GetEnabledAllModule(IServiceCollection services)
         {
             var findTypes = AssemblyHelper.FindTypes(LuckAppModule.IsAppModule);
-            var modules = findTypes.Select(o => CreateModule(services, o)).Where(o => o.IsNotNull()).Distinct();
-            return modules.ToList();
+            var modules = findTypes.Select(o => CreateModule(services, o)).Where(o => o is not null);
+            return modules.Distinct()!;
         }
 
         /// <summary>
@@ -75,55 +102,17 @@ namespace Luck.AppModule
         }
 
         /// <summary>
-        /// 获取所有需要加载的模块
-        /// </summary>
-        /// <returns></returns>
-        protected virtual IReadOnlyList<IAppModule> LoadModules()
-        {
-            var modules = new List<IAppModule>();
-
-            var module = Source.FirstOrDefault(o => o.GetType() == StartupModuleType);
-            if (module == null)
-            {
-                throw new Exception($"类型为“{StartupModuleType.FullName}”的模块实例无法找到");
-            }
-            modules.Add(module);
-            var dependedTypes = module.GetDependedTypes();
-            foreach (var dependType in dependedTypes.Where(LuckAppModule.IsAppModule))
-            {
-                var dependModule = Source.Find(m => m.GetType() == dependType);
-                if (dependModule == null)
-                {
-                    throw new Exception($"加载模块{module.GetType().FullName}时无法找到依赖模块{dependType.FullName}");
-                }
-                modules.AddIfNotContains(dependModule);
-            }
-            return modules;
-        }
-
-        /// <summary>
         /// 创建模块
         /// </summary>
         /// <param name="services"></param>
         /// <param name="moduleType"></param>
         /// <exception cref="ArgumentNullException"></exception>
         /// <returns></returns>
-        private static IAppModule CreateModule(IServiceCollection services, Type moduleType)
+        private static IAppModule? CreateModule(IServiceCollection services, Type moduleType)
         {
-            var invoke = Expression.Lambda(Expression.New(moduleType)).Compile().DynamicInvoke();
-
-
-            if (invoke == null)
-            {
-                throw new ArgumentNullException(nameof(invoke));
-            }
-            var module = (IAppModule)invoke;
-
-
-            if (module == null)
-                throw new ArgumentNullException(nameof(module));
-
-            if (module.Enable == false)
+            var module = Expression.Lambda(Expression.New(moduleType)).Compile().DynamicInvoke() as IAppModule;
+            ArgumentNullException.ThrowIfNull(module, nameof(moduleType));
+            if (!module.Enable)
             {
                 return null;
             }
@@ -136,7 +125,7 @@ namespace Luck.AppModule
         /// </summary>
         public virtual void Dispose()
         {
-            Source?.Clear();
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/framework/Luck.AspNetCore/Luck.AspNetCore.csproj
+++ b/src/framework/Luck.AspNetCore/Luck.AspNetCore.csproj
@@ -11,11 +11,9 @@
     <ItemGroup Condition="$(TargetFramework) == 'net6.0'">
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
     </ItemGroup>
-
     <ItemGroup Condition="$(TargetFramework) == 'net7.0'">
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
     </ItemGroup>
-
     <ItemGroup Condition="$(TargetFramework) == 'net8.0'">
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
     </ItemGroup>

--- a/src/framework/Luck.AspNetCore/Luck.AspNetCore.csproj
+++ b/src/framework/Luck.AspNetCore/Luck.AspNetCore.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <Import Project="..\..\common.props" />
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/src/framework/Luck.AspNetCore/Luck.AspNetCore.csproj
+++ b/src/framework/Luck.AspNetCore/Luck.AspNetCore.csproj
@@ -5,18 +5,18 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>
-
-    <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="2.2.0" />
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.2" />
-    </ItemGroup>
-
     <ItemGroup>
         <ProjectReference Include="..\Luck.Framework\Luck.Framework.csproj" />
     </ItemGroup>
+    <ItemGroup Condition="$(TargetFramework) == 'net6.0'">
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    </ItemGroup>
 
+    <ItemGroup Condition="$(TargetFramework) == 'net7.0'">
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    </ItemGroup>
 
+    <ItemGroup Condition="$(TargetFramework) == 'net8.0'">
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    </ItemGroup>
 </Project>

--- a/src/framework/Luck.AspNetCore/Properties/launchSettings.json
+++ b/src/framework/Luck.AspNetCore/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "Luck.AspNetCore": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:55797;http://localhost:55798"
+    }
+  }
+}

--- a/src/framework/Luck.AutoDependencyInjection/AppModuleExtensions.cs
+++ b/src/framework/Luck.AutoDependencyInjection/AppModuleExtensions.cs
@@ -1,8 +1,9 @@
-﻿using Luck.Framework.Infrastructure;
+﻿using Luck.AppModule;
+using Luck.Framework.Infrastructure;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Luck.AppModule
+namespace Luck.AutoDependencyInjection
 {
     /// <summary>
     /// 

--- a/src/framework/Luck.AutoDependencyInjection/ApplicationInitializationExtensions.cs
+++ b/src/framework/Luck.AutoDependencyInjection/ApplicationInitializationExtensions.cs
@@ -2,7 +2,7 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Luck.AppModule
+namespace Luck.AutoDependencyInjection
 {
     /// <summary>
     /// 

--- a/src/framework/Luck.AutoDependencyInjection/Luck.AutoDependencyInjection.csproj
+++ b/src/framework/Luck.AutoDependencyInjection/Luck.AutoDependencyInjection.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <Import Project="..\..\common.props"/>
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/src/framework/Luck.AutoDependencyInjection/Luck.AutoDependencyInjection.csproj
+++ b/src/framework/Luck.AutoDependencyInjection/Luck.AutoDependencyInjection.csproj
@@ -1,17 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-	<Import Project="..\..\common.props" />
-	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<Nullable>enable</Nullable>
-	</PropertyGroup>
-
-	<ItemGroup>
-	  <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<ProjectReference Include="..\Luck.AppModule\Luck.AppModule.csproj" />
-	</ItemGroup>
-
+    <Import Project="..\..\common.props"/>
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+    <ItemGroup Condition="$(TargetFramework) == 'net6.0'">
+        <FrameworkReference Include="Microsoft.AspNetCore.App"/>
+    </ItemGroup>
+    <ItemGroup Condition="$(TargetFramework) == 'net7.0'">
+        <FrameworkReference Include="Microsoft.AspNetCore.App"/>
+    </ItemGroup>
+    <ItemGroup Condition="$(TargetFramework) == 'net8.0'">
+        <FrameworkReference Include="Microsoft.AspNetCore.App"/>
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\Luck.AppModule\Luck.AppModule.csproj"/>
+    </ItemGroup>
 </Project>

--- a/src/framework/Luck.AutoDependencyInjection/PropertyInjection/ServiceCollectionExtension.cs
+++ b/src/framework/Luck.AutoDependencyInjection/PropertyInjection/ServiceCollectionExtension.cs
@@ -14,7 +14,7 @@ namespace Luck.AutoDependencyInjection.PropertyInjection
         /// <returns></returns>
         public static void UsePropertyInjection(this IHostBuilder hostBuilder)
         {
-            hostBuilder.UseServiceProviderFactory(new PropertyInjectionServiceProviderFactory()).ConfigureServices(ConfigureServices);
+            //hostBuilder.UseServiceProviderFactory(new PropertyInjectionServiceProviderFactory()).ConfigureServices(ConfigureServices);
         }
 
         private static void ConfigureServices(IServiceCollection services)

--- a/src/framework/Luck.DDD.Domain/Domain/AggregateRoots/AggregateRootWithIdentity.cs
+++ b/src/framework/Luck.DDD.Domain/Domain/AggregateRoots/AggregateRootWithIdentity.cs
@@ -2,7 +2,7 @@
 {
     public class AggregateRootWithIdentity<TKey> : AggregateRootBase
     {
-        public AggregateRootWithIdentity(TKey id)
+        protected AggregateRootWithIdentity(TKey id)
         {
             if (id == null)
                 throw new ArgumentNullException(nameof(id));

--- a/src/framework/Luck.DDD.Domain/Luck.DDD.Domain.csproj
+++ b/src/framework/Luck.DDD.Domain/Luck.DDD.Domain.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <Import Project="..\..\common.props" />
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/src/framework/Luck.Dapper.ClickHouse/Luck.Dapper.ClickHouse.csproj
+++ b/src/framework/Luck.Dapper.ClickHouse/Luck.Dapper.ClickHouse.csproj
@@ -10,6 +10,6 @@
       <ProjectReference Include="..\Luck.Dapper\Luck.Dapper.csproj" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Octonica.ClickHouseClient" Version="2.2.9" />
+        <PackageReference Include="Octonica.ClickHouseClient" Version="2.2.11" />
     </ItemGroup>
 </Project>

--- a/src/framework/Luck.Dapper.ClickHouse/Luck.Dapper.ClickHouse.csproj
+++ b/src/framework/Luck.Dapper.ClickHouse/Luck.Dapper.ClickHouse.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <Import Project="..\..\common.props" />
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/src/framework/Luck.Dapper/Luck.Dapper.csproj
+++ b/src/framework/Luck.Dapper/Luck.Dapper.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <Import Project="..\..\common.props" />
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/src/framework/Luck.Dapper/Luck.Dapper.csproj
+++ b/src/framework/Luck.Dapper/Luck.Dapper.csproj
@@ -10,6 +10,6 @@
       <ProjectReference Include="..\Luck.Framework\Luck.Framework.csproj" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Dapper" Version="2.0.123" />
+        <PackageReference Include="Dapper" Version="2.1.11" />
     </ItemGroup>
 </Project>

--- a/src/framework/Luck.EntityFrameworkCore.MemoryDataBase/Luck.EntityFrameworkCore.MemoryDataBase.csproj
+++ b/src/framework/Luck.EntityFrameworkCore.MemoryDataBase/Luck.EntityFrameworkCore.MemoryDataBase.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+    <Import Project="..\..\common.props" />
+    <PropertyGroup>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+    <ItemGroup Condition="$(TargetFramework) == 'net6.0'">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.24" />
+    </ItemGroup>
+    <ItemGroup Condition="$(TargetFramework) == 'net7.0'">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.13" />
+    </ItemGroup>
+    
+    <ItemGroup Condition="$(TargetFramework) == 'net8.0'">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0-rc.2.23480.1" />
+    </ItemGroup>
+    
+    <ItemGroup>
+      <ProjectReference Include="..\Luck.EntityFrameworkCore\Luck.EntityFrameworkCore.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/framework/Luck.EntityFrameworkCore.MemoryDataBase/MemoryDrivenProvider.cs
+++ b/src/framework/Luck.EntityFrameworkCore.MemoryDataBase/MemoryDrivenProvider.cs
@@ -1,0 +1,24 @@
+﻿using Luck.EntityFrameworkCore.DbContextDrivenProvides;
+using Luck.EntityFrameworkCore.DbContexts;
+using Microsoft.EntityFrameworkCore;
+
+namespace Luck.EntityFrameworkCore.MemoryDatabase;
+
+public class MemoryDrivenProvider: IDbContextDrivenProvider
+{
+    public DataBaseType Type => DataBaseType.MemoryDataBase;
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="builder"></param>
+    /// <param name="connectionString"></param>
+    /// <param name="querySplittingBehavior">拆分查询配置，默认使用拆分查询</param>
+    /// <typeparam name="TDbContext"></typeparam>
+    /// <returns></returns>
+    public DbContextOptionsBuilder Builder<TDbContext>(DbContextOptionsBuilder builder, string connectionString, QuerySplittingBehavior querySplittingBehavior = QuerySplittingBehavior.SplitQuery) where TDbContext : ILuckDbContext
+    {
+        builder.UseInMemoryDatabase(Guid.NewGuid().ToString());
+        return builder;
+    }
+}

--- a/src/framework/Luck.EntityFrameworkCore.MemoryDataBase/ServiceCollectionExtension.cs
+++ b/src/framework/Luck.EntityFrameworkCore.MemoryDataBase/ServiceCollectionExtension.cs
@@ -1,0 +1,13 @@
+﻿using Luck.EntityFrameworkCore.DbContextDrivenProvides;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Luck.EntityFrameworkCore.MemoryDatabase;
+
+public class ServiceCollectionExtension
+{
+    public virtual IServiceCollection AddMemoryDriven(IServiceCollection services)
+    {
+        services.AddSingleton<IDbContextDrivenProvider, MemoryDrivenProvider>();
+        return services;
+    }
+}

--- a/src/framework/Luck.EntityFrameworkCore.MemoryDataBase/build_package.sh
+++ b/src/framework/Luck.EntityFrameworkCore.MemoryDataBase/build_package.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+echo "请输入NUGET_API_KEY"
+read NUGET_API_KEY
+rm bin/Release/*.nupkg
+dotnet build -c Release
+dotnet pack -c Release
+dotnet nuget push bin/Release/*.nupkg -k $NUGET_API_KEY -s https://api.nuget.org/v3/index.json

--- a/src/framework/Luck.EntityFrameworkCore.MySQL/Luck.EntityFrameworkCore.MySQL.csproj
+++ b/src/framework/Luck.EntityFrameworkCore.MySQL/Luck.EntityFrameworkCore.MySQL.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <Import Project="..\..\common.props" />
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/src/framework/Luck.EntityFrameworkCore.MySQL/Luck.EntityFrameworkCore.MySQL.csproj
+++ b/src/framework/Luck.EntityFrameworkCore.MySQL/Luck.EntityFrameworkCore.MySQL.csproj
@@ -4,8 +4,14 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>
-    <ItemGroup>
+    <ItemGroup Condition="$(TargetFramework) == 'net6.0'">
         <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="6.0.2" />
+    </ItemGroup>
+    <ItemGroup Condition="$(TargetFramework) == 'net7.0'">
+        <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="7.0.0" />
+    </ItemGroup>
+    <ItemGroup Condition="$(TargetFramework) == 'net8.0'">
+        <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.0-beta.1" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Luck.EntityFrameworkCore\Luck.EntityFrameworkCore.csproj" />

--- a/src/framework/Luck.EntityFrameworkCore.MySQL/MySqlDrivenProvider.cs
+++ b/src/framework/Luck.EntityFrameworkCore.MySQL/MySqlDrivenProvider.cs
@@ -8,7 +8,7 @@ namespace Luck.EntityFrameworkCore.MySQL
     /// <summary>
     /// Mysql驱动
     /// </summary>
-    public class MySqlDbContextDrivenProvider : IDbContextDrivenProvider
+    public class MySqlDrivenProvider : IDbContextDrivenProvider
     {
         public DataBaseType Type => DataBaseType.MySql;
 

--- a/src/framework/Luck.EntityFrameworkCore.MySQL/ServiceCollectionExtension.cs
+++ b/src/framework/Luck.EntityFrameworkCore.MySQL/ServiceCollectionExtension.cs
@@ -11,9 +11,9 @@ public class ServiceCollectionExtension
     /// </summary>
     /// <param name="services"></param>
     /// <returns></returns>
-    public virtual IServiceCollection AddMySQLDriven(IServiceCollection services)
+    public virtual IServiceCollection AddMySqlDriven(IServiceCollection services)
     {
-        services.AddSingleton<IDbContextDrivenProvider, MySqlDbContextDrivenProvider>();
+        services.AddSingleton<IDbContextDrivenProvider, MySqlDrivenProvider>();
         return services;
     }
 }

--- a/src/framework/Luck.EntityFrameworkCore.MySQL/ServiceCollectionExtension.cs
+++ b/src/framework/Luck.EntityFrameworkCore.MySQL/ServiceCollectionExtension.cs
@@ -11,7 +11,7 @@ public class ServiceCollectionExtension
     /// </summary>
     /// <param name="services"></param>
     /// <returns></returns>
-    public virtual IServiceCollection AddMySqlDriven(IServiceCollection services)
+    public virtual IServiceCollection AddMemoryDataBase(IServiceCollection services)
     {
         services.AddSingleton<IDbContextDrivenProvider, MySqlDrivenProvider>();
         return services;

--- a/src/framework/Luck.EntityFrameworkCore.PostgreSQL/Luck.EntityFrameworkCore.PostgreSQL.csproj
+++ b/src/framework/Luck.EntityFrameworkCore.PostgreSQL/Luck.EntityFrameworkCore.PostgreSQL.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <Import Project="..\..\common.props" />
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/src/framework/Luck.EntityFrameworkCore.PostgreSQL/Luck.EntityFrameworkCore.PostgreSQL.csproj
+++ b/src/framework/Luck.EntityFrameworkCore.PostgreSQL/Luck.EntityFrameworkCore.PostgreSQL.csproj
@@ -4,8 +4,14 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>
-    <ItemGroup>
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.7" />
+    <ItemGroup Condition="$(TargetFramework) == 'net6.0'">
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.22" />
+    </ItemGroup>
+    <ItemGroup Condition="$(TargetFramework) == 'net7.0'">
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.11" />
+    </ItemGroup>
+    <ItemGroup Condition="$(TargetFramework) == 'net8.0'">
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0-rc.2" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Luck.EntityFrameworkCore\Luck.EntityFrameworkCore.csproj" />

--- a/src/framework/Luck.EntityFrameworkCore.PostgreSQL/PostgreSqlDrivenProvider.cs
+++ b/src/framework/Luck.EntityFrameworkCore.PostgreSQL/PostgreSqlDrivenProvider.cs
@@ -7,9 +7,9 @@ namespace Luck.EntityFrameworkCore.PostgreSQL
     /// <summary>
     ///  PostgreSql驱动
     /// </summary>
-    public class PostgreSqlDbContextDrivenProvider : IDbContextDrivenProvider
+    public class PostgreSqlDrivenProvider : IDbContextDrivenProvider
     {
-        public DataBaseType Type => DataBaseType.PostgreSQL;
+        public DataBaseType Type => DataBaseType.PostgreSql;
 
         /// <summary>
         /// 

--- a/src/framework/Luck.EntityFrameworkCore.PostgreSQL/ServiceCollectionExtension.cs
+++ b/src/framework/Luck.EntityFrameworkCore.PostgreSQL/ServiceCollectionExtension.cs
@@ -1,7 +1,7 @@
-﻿using Luck.EntityFrameworkCore.PostgreSQL;
+﻿using Luck.EntityFrameworkCore.DbContextDrivenProvides;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Luck.EntityFrameworkCore.DbContextDrivenProvides;
+namespace Luck.EntityFrameworkCore.PostgreSQL;
 
 public static class ServiceCollectionExtension
 {
@@ -15,7 +15,7 @@ public static class ServiceCollectionExtension
     // ReSharper disable once IdentifierTypo
     public static IServiceCollection AddPostgreSQLDriven(this IServiceCollection services)
     {
-        services.AddSingleton<IDbContextDrivenProvider, PostgreSqlDbContextDrivenProvider>();
+        services.AddSingleton<IDbContextDrivenProvider, PostgreSqlDrivenProvider>();
         return services;
     }
 }

--- a/src/framework/Luck.EntityFrameworkCore/DbContextDrivenProvides/DataBaseType.cs
+++ b/src/framework/Luck.EntityFrameworkCore/DbContextDrivenProvides/DataBaseType.cs
@@ -16,6 +16,11 @@
         /// <summary>
         /// PostgreSQL数据库类型
         /// </summary>
-        PostgreSQL
+        PostgreSql,
+        
+        /// <summary>
+        /// 内存数据库
+        /// </summary>
+        MemoryDataBase
     }
 }

--- a/src/framework/Luck.EntityFrameworkCore/DbContexts/LuckDbContextBase.cs
+++ b/src/framework/Luck.EntityFrameworkCore/DbContexts/LuckDbContextBase.cs
@@ -1,23 +1,18 @@
 ﻿using Luck.EntityFrameworkCore.Extensions;
 using Luck.Framework.Utilities;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Luck.EntityFrameworkCore.DbContexts
 {
     /// <summary>
     /// 类类上下文
     /// </summary>
-    public abstract class LuckDbContextBase : DbContext, ILuckDbContext
+    public abstract class LuckDbContextBase(DbContextOptions options, IServiceProvider serviceProvider) : DbContext(options), ILuckDbContext
     {
         // ReSharper disable once MemberCanBePrivate.Global
-        protected IServiceProvider ServiceProvider { get; set; }
+        protected IServiceProvider ServiceProvider { get; set; } = Check.NotNull(serviceProvider, nameof(serviceProvider));
 
         // ReSharper disable once PublicConstructorInAbstractClass
-        public LuckDbContextBase(DbContextOptions options, IServiceProvider serviceProvider) : base(options)
-        {
-            ServiceProvider = Check.NotNull(serviceProvider, nameof(serviceProvider));
-        }
 
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/src/framework/Luck.EntityFrameworkCore/Luck.EntityFrameworkCore.csproj
+++ b/src/framework/Luck.EntityFrameworkCore/Luck.EntityFrameworkCore.csproj
@@ -19,10 +19,6 @@
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0-rc.2.23480.1" />
     </ItemGroup>
     <ItemGroup>
-
-    </ItemGroup>
-
-    <ItemGroup>
         <ProjectReference Include="..\Luck.AppModule\Luck.AppModule.csproj" />
         <ProjectReference Include="..\Luck.DDD.Domain\Luck.DDD.Domain.csproj" />
         <ProjectReference Include="..\Luck.Framework\Luck.Framework.csproj" />

--- a/src/framework/Luck.EntityFrameworkCore/Luck.EntityFrameworkCore.csproj
+++ b/src/framework/Luck.EntityFrameworkCore/Luck.EntityFrameworkCore.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <Import Project="..\..\common.props" />
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/src/framework/Luck.EntityFrameworkCore/Luck.EntityFrameworkCore.csproj
+++ b/src/framework/Luck.EntityFrameworkCore/Luck.EntityFrameworkCore.csproj
@@ -6,9 +6,21 @@
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
-    <ItemGroup>
+
+    <ItemGroup Condition="$(TargetFramework) == 'net6.0'">
         <PackageReference Include="EFCore.NamingConventions" Version="6.0.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.10" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.23" />
+    </ItemGroup>
+    <ItemGroup Condition="$(TargetFramework) == 'net7.0'">
+        <PackageReference Include="EFCore.NamingConventions" Version="7.0.2" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.12" />
+    </ItemGroup>
+    <ItemGroup Condition="$(TargetFramework) == 'net8.0'">
+        <PackageReference Include="EFCore.NamingConventions" Version="7.0.2" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0-rc.2.23480.1" />
+    </ItemGroup>
+    <ItemGroup>
+
     </ItemGroup>
 
     <ItemGroup>

--- a/src/framework/Luck.EventBus.Kafka/Luck.EventBus.Kafka.csproj
+++ b/src/framework/Luck.EventBus.Kafka/Luck.EventBus.Kafka.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
+    <Import Project="..\..\common.props" />
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/src/framework/Luck.EventBus.RabbitMQ/IntegrationEventBusRabbitMq.cs
+++ b/src/framework/Luck.EventBus.RabbitMQ/IntegrationEventBusRabbitMq.cs
@@ -16,7 +16,7 @@ using System.Text;
 using System.Text.Json;
 using Luck.EventBus.RabbitMQ.Diagnostics;
 using Luck.Framework.Infrastructure;
-using ExchangeType = RabbitMQ.Client.ExchangeType;
+
 
 namespace Luck.EventBus.RabbitMQ;
 

--- a/src/framework/Luck.EventBus.RabbitMQ/Luck.EventBus.RabbitMQ.csproj
+++ b/src/framework/Luck.EventBus.RabbitMQ/Luck.EventBus.RabbitMQ.csproj
@@ -22,7 +22,7 @@
     </ItemGroup>
     
     <ItemGroup>
-        <PackageReference Include="Polly" Version="7.2.3" />
-        <PackageReference Include="RabbitMQ.Client" Version="6.4.0" />
+        <PackageReference Include="Polly" Version="7.2.4" />
+        <PackageReference Include="RabbitMQ.Client" Version="6.6.0" />
     </ItemGroup>
 </Project>

--- a/src/framework/Luck.EventBus.RabbitMQ/Luck.EventBus.RabbitMQ.csproj
+++ b/src/framework/Luck.EventBus.RabbitMQ/Luck.EventBus.RabbitMQ.csproj
@@ -9,6 +9,18 @@
     <ItemGroup>
         <ProjectReference Include="..\Luck.Framework\Luck.Framework.csproj" />
     </ItemGroup>
+    
+    <ItemGroup  Condition="'$(TargetFramework)' == 'net6.0'">
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
+    </ItemGroup>
+
+    <ItemGroup  Condition="'$(TargetFramework)' == 'net7.0'">
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
+    </ItemGroup>
+
+    <ItemGroup  Condition="'$(TargetFramework)' == 'net8.0'">
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0-rc.2.23479.6" />
+    </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Polly" Version="7.2.3" />
         <PackageReference Include="RabbitMQ.Client" Version="6.4.0" />

--- a/src/framework/Luck.EventBus.RabbitMQ/Luck.EventBus.RabbitMQ.csproj
+++ b/src/framework/Luck.EventBus.RabbitMQ/Luck.EventBus.RabbitMQ.csproj
@@ -10,18 +10,6 @@
         <ProjectReference Include="..\Luck.Framework\Luck.Framework.csproj" />
     </ItemGroup>
     
-<!--    <ItemGroup  Condition="'$(TargetFramework)' == 'net6.0'">-->
-<!--        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />-->
-<!--    </ItemGroup>-->
-
-<!--    <ItemGroup  Condition="'$(TargetFramework)' == 'net7.0'">-->
-<!--        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />-->
-<!--    </ItemGroup>-->
-
-<!--    <ItemGroup  Condition="'$(TargetFramework)' == 'net8.0'">-->
-<!--        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0-rc.2.23479.6" />-->
-<!--    </ItemGroup>-->
-
     <ItemGroup Condition="$(TargetFramework) == 'net6.0'">
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
     </ItemGroup>

--- a/src/framework/Luck.EventBus.RabbitMQ/Luck.EventBus.RabbitMQ.csproj
+++ b/src/framework/Luck.EventBus.RabbitMQ/Luck.EventBus.RabbitMQ.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <Import Project="..\..\common.props" />
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/src/framework/Luck.EventBus.RabbitMQ/Luck.EventBus.RabbitMQ.csproj
+++ b/src/framework/Luck.EventBus.RabbitMQ/Luck.EventBus.RabbitMQ.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk">
     <Import Project="..\..\common.props" />
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
@@ -21,6 +21,19 @@
 <!--    <ItemGroup  Condition="'$(TargetFramework)' == 'net8.0'">-->
 <!--        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0-rc.2.23479.6" />-->
 <!--    </ItemGroup>-->
+
+    <ItemGroup Condition="$(TargetFramework) == 'net6.0'">
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    </ItemGroup>
+
+    <ItemGroup Condition="$(TargetFramework) == 'net7.0'">
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    </ItemGroup>
+
+    <ItemGroup Condition="$(TargetFramework) == 'net8.0'">
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    </ItemGroup>
+    
     <ItemGroup>
         <PackageReference Include="Polly" Version="7.2.3" />
         <PackageReference Include="RabbitMQ.Client" Version="6.4.0" />

--- a/src/framework/Luck.EventBus.RabbitMQ/Luck.EventBus.RabbitMQ.csproj
+++ b/src/framework/Luck.EventBus.RabbitMQ/Luck.EventBus.RabbitMQ.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk.Web">
     <Import Project="..\..\common.props" />
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
@@ -10,17 +10,17 @@
         <ProjectReference Include="..\Luck.Framework\Luck.Framework.csproj" />
     </ItemGroup>
     
-    <ItemGroup  Condition="'$(TargetFramework)' == 'net6.0'">
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
-    </ItemGroup>
+<!--    <ItemGroup  Condition="'$(TargetFramework)' == 'net6.0'">-->
+<!--        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />-->
+<!--    </ItemGroup>-->
 
-    <ItemGroup  Condition="'$(TargetFramework)' == 'net7.0'">
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
-    </ItemGroup>
+<!--    <ItemGroup  Condition="'$(TargetFramework)' == 'net7.0'">-->
+<!--        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />-->
+<!--    </ItemGroup>-->
 
-    <ItemGroup  Condition="'$(TargetFramework)' == 'net8.0'">
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0-rc.2.23479.6" />
-    </ItemGroup>
+<!--    <ItemGroup  Condition="'$(TargetFramework)' == 'net8.0'">-->
+<!--        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0-rc.2.23479.6" />-->
+<!--    </ItemGroup>-->
     <ItemGroup>
         <PackageReference Include="Polly" Version="7.2.3" />
         <PackageReference Include="RabbitMQ.Client" Version="6.4.0" />

--- a/src/framework/Luck.EventBus.RabbitMQ/Properties/launchSettings.json
+++ b/src/framework/Luck.EventBus.RabbitMQ/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "Luck.EventBus.RabbitMQ": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:55800;http://localhost:55801"
+    }
+  }
+}

--- a/src/framework/Luck.EventBus.RabbitMQ/RabbitMqSubscribeService.cs
+++ b/src/framework/Luck.EventBus.RabbitMQ/RabbitMqSubscribeService.cs
@@ -1,7 +1,4 @@
-﻿using System.Reflection;
-using Luck.Framework.Event;
-using Luck.Framework.Extensions;
-using Luck.Framework.Infrastructure;
+﻿using Luck.Framework.Event;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
@@ -10,19 +7,11 @@ namespace Luck.EventBus.RabbitMQ
     /// <summary>
     /// 后台任务进行事件订阅
     /// </summary>
-    public class RabbitMqIntegrationEventBusBackgroundServiceSubscribe : BackgroundService
+    public class RabbitMqSubscribeService(IServiceProvider serviceProvider) : BackgroundService
     {
-
-        private readonly IServiceProvider _rootServiceProvider;
-
-        public RabbitMqIntegrationEventBusBackgroundServiceSubscribe(IServiceProvider serviceProvider)
-        {
-            _rootServiceProvider = serviceProvider;
-        }
-
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
-            using (var scope = _rootServiceProvider.CreateScope())
+            using (var scope = serviceProvider.CreateScope())
             {
                 var eventBus= scope.ServiceProvider.GetService<IIntegrationEventBus>();
                 if (eventBus is null)

--- a/src/framework/Luck.EventBus.RabbitMQ/ServiceCollectionExtension.cs
+++ b/src/framework/Luck.EventBus.RabbitMQ/ServiceCollectionExtension.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 => new IntegrationEventBusRabbitMq(config.RetryCount, serviceProvider)
             );
             service.AddSingleton<IIntegrationEventBusSubscriptionsManager, RabbitMqEventBusSubscriptionsManager>();
-            service.AddHostedService<RabbitMqIntegrationEventBusBackgroundServiceSubscribe>();
+            service.AddHostedService<RabbitMqSubscribeService>();
             return service;
         }
 

--- a/src/framework/Luck.Framework/Extensions/CollectionExtensions.cs
+++ b/src/framework/Luck.Framework/Extensions/CollectionExtensions.cs
@@ -68,19 +68,6 @@ namespace Luck.Framework.Extensions
         }
 
         /// <summary>
-        /// 去重
-        /// </summary>
-        /// <typeparam name="TSource">去重数据源</typeparam>
-        /// <typeparam name="TKey">键</typeparam>
-        /// <param name="source">数据源</param>
-        /// <param name="keySelector">键条件</param>
-        /// <returns>返回去重后集合数据</returns>
-        public static IList<TSource> ToDistinctBy<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector)
-        {
-            return source.DistinctBy(keySelector).ToList();
-        }
-
-        /// <summary>
         /// 把集合转成SqlIn
         /// </summary>
         /// <typeparam name="TSource">源</typeparam>

--- a/src/framework/Luck.Framework/Extensions/IEnumerableExtensions.cs
+++ b/src/framework/Luck.Framework/Extensions/IEnumerableExtensions.cs
@@ -1,0 +1,1016 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Linq.Expressions;
+using System.Text;
+
+namespace Luck.Framework.Extensions;
+
+/// <summary>
+/// </summary>
+public static class EnumerableExtensions
+{
+    /// <summary>
+    /// 按字段属性判等取交集
+    /// </summary>
+    /// <typeparam name="TFirst"></typeparam>
+    /// <typeparam name="TSecond"></typeparam>
+    /// <param name="second"></param>
+    /// <param name="condition"></param>
+    /// <param name="first"></param>
+    /// <returns></returns>
+    public static IEnumerable<TFirst> IntersectBy<TFirst, TSecond>(this IEnumerable<TFirst> first, IEnumerable<TSecond> second, Func<TFirst, TSecond, bool> condition)
+    {
+        return first.Where(f => second.Any(s => condition(f, s)));
+    }
+
+    /// <summary>
+    /// 按字段属性判等取交集
+    /// </summary>
+    /// <typeparam name="TSource"></typeparam>
+    /// <typeparam name="TKey"></typeparam>
+    /// <param name="first"></param>
+    /// <param name="second"></param>
+    /// <param name="keySelector"></param>
+    /// <returns></returns>
+    public static IEnumerable<TSource> IntersectBy<TSource, TKey>(this IEnumerable<TSource> first, IEnumerable<TSource> second, Func<TSource, TKey> keySelector) => first.IntersectBy(second, keySelector, null);
+
+    /// <summary>
+    /// 按字段属性判等取交集
+    /// </summary>
+    /// <typeparam name="TSource"></typeparam>
+    /// <typeparam name="TKey"></typeparam>
+    /// <param name="first"></param>
+    /// <param name="second"></param>
+    /// <param name="keySelector"></param>
+    /// <param name="comparer"></param>
+    /// <returns></returns>
+    public static IEnumerable<TSource> IntersectBy<TSource, TKey>(this IEnumerable<TSource> first, IEnumerable<TSource> second, Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? comparer) =>
+        first is null
+            ? throw new ArgumentNullException(nameof(first))
+            : second is null
+                ? throw new ArgumentNullException(nameof(second))
+                : keySelector is null
+                    ? throw new ArgumentNullException(nameof(keySelector))
+                    : IntersectByIterator(first, second, keySelector, comparer);
+
+    private static IEnumerable<TSource> IntersectByIterator<TSource, TKey>(IEnumerable<TSource> first, IEnumerable<TSource> second, Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? comparer)
+    {
+        var set = new HashSet<TKey>(second.Select(keySelector), comparer);
+        foreach (var source in first)
+        {
+            if (set.Remove(keySelector(source)))
+                yield return source;
+        }
+    }
+
+    /// <summary>
+    /// 多个集合取交集元素
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="source"></param>
+    /// <returns></returns>
+    public static IEnumerable<T> IntersectAll<T>(this IEnumerable<IEnumerable<T>> source)
+    {
+        return source.Aggregate((current, item) => current.Intersect(item));
+    }
+
+    /// <summary>
+    /// 多个集合取交集元素
+    /// </summary>
+    /// <typeparam name="TSource"></typeparam>
+    /// <typeparam name="TKey"></typeparam>
+    /// <param name="source"></param>
+    /// <param name="keySelector"></param>
+    /// <returns></returns>
+    public static IEnumerable<TSource> IntersectAll<TSource, TKey>(this IEnumerable<IEnumerable<TSource>> source, Func<TSource, TKey> keySelector)
+    {
+        return source.Aggregate((current, item) => current.IntersectBy(item, keySelector));
+    }
+
+    /// <summary>
+    /// 多个集合取交集元素
+    /// </summary>
+    /// <typeparam name="TSource"></typeparam>
+    /// <typeparam name="TKey"></typeparam>
+    /// <param name="source"></param>
+    /// <param name="keySelector"></param>
+    /// <param name="comparer"></param>
+    /// <returns></returns>
+    public static IEnumerable<TSource> IntersectAll<TSource, TKey>(this IEnumerable<IEnumerable<TSource>> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
+    {
+        return source.Aggregate((current, item) => current.IntersectBy(item, keySelector, comparer));
+    }
+
+    /// <summary>
+    /// 多个集合取交集元素
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="source"></param>
+    /// <param name="comparer"></param>
+    /// <returns></returns>
+    public static IEnumerable<T> IntersectAll<T>(this IEnumerable<IEnumerable<T>> source, IEqualityComparer<T> comparer)
+    {
+        return source.Aggregate((current, item) => current.Intersect(item, comparer));
+    }
+
+    /// <summary>
+    /// 按字段属性判等取差集
+    /// </summary>
+    /// <typeparam name="TFirst"></typeparam>
+    /// <typeparam name="TSecond"></typeparam>
+    /// <param name="second"></param>
+    /// <param name="condition"></param>
+    /// <param name="first"></param>
+    /// <returns></returns>
+    public static IEnumerable<TFirst> ExceptBy<TFirst, TSecond>(this IEnumerable<TFirst> first, IEnumerable<TSecond> second, Func<TFirst, TSecond, bool> condition)
+    {
+        return first.Where(f => !second.Any(s => condition(f, s)));
+    }
+
+    /// <summary>
+    /// 按字段去重
+    /// </summary>
+    /// <typeparam name="TSource"></typeparam>
+    /// <typeparam name="TKey"></typeparam>
+    /// <param name="source"></param>
+    /// <param name="keySelector"></param>
+    /// <returns></returns>
+    public static IEnumerable<TSource> DistinctBy<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(keySelector);
+        return source.GroupBy(keySelector).Select(x => x.First());
+    }
+
+    /// <summary>
+    /// 按字段属性判等取交集
+    /// </summary>
+    /// <typeparam name="TSource"></typeparam>
+    /// <typeparam name="TKey"></typeparam>
+    /// <param name="first"></param>
+    /// <param name="second"></param>
+    /// <param name="keySelector"></param>
+    /// <returns></returns>
+    public static IEnumerable<TSource> IntersectBy<TSource, TKey>(this IEnumerable<TSource> first, IEnumerable<TKey> second, Func<TSource, TKey> keySelector) => first.IntersectBy(second, keySelector, null);
+
+    /// <summary>
+    /// 按字段属性判等取交集
+    /// </summary>
+    /// <typeparam name="TSource"></typeparam>
+    /// <typeparam name="TKey"></typeparam>
+    /// <param name="first"></param>
+    /// <param name="second"></param>
+    /// <param name="keySelector"></param>
+    /// <param name="comparer"></param>
+    /// <returns></returns>
+    public static IEnumerable<TSource> IntersectBy<TSource, TKey>(this IEnumerable<TSource> first, IEnumerable<TKey> second, Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? comparer)
+    {
+        ArgumentNullException.ThrowIfNull(first);
+        ArgumentNullException.ThrowIfNull(second);
+        ArgumentNullException.ThrowIfNull(keySelector);
+        return IntersectByIterator(first, second, keySelector, comparer);
+    }
+
+    private static IEnumerable<TSource> IntersectByIterator<TSource, TKey>(IEnumerable<TSource> first, IEnumerable<TKey> second, Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? comparer)
+    {
+        var set = new HashSet<TKey>(second, comparer);
+        foreach (var source in first)
+        {
+            if (set.Remove(keySelector(source)))
+                yield return source;
+        }
+    }
+
+    /// <summary>
+    /// 按字段属性判等取差集
+    /// </summary>
+    /// <typeparam name="TSource"></typeparam>
+    /// <typeparam name="TKey"></typeparam>
+    /// <param name="first"></param>
+    /// <param name="second"></param>
+    /// <param name="keySelector"></param>
+    /// <returns></returns>
+    public static IEnumerable<TSource> ExceptBy<TSource, TKey>(this IEnumerable<TSource> first, IEnumerable<TKey> second, Func<TSource, TKey> keySelector) => first.ExceptBy(second, keySelector, null);
+
+    /// <summary>
+    /// 按字段属性判等取差集
+    /// </summary>
+    /// <typeparam name="TSource"></typeparam>
+    /// <typeparam name="TKey"></typeparam>
+    /// <param name="first"></param>
+    /// <param name="second"></param>
+    /// <param name="keySelector"></param>
+    /// <param name="comparer"></param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentNullException"></exception>
+    public static IEnumerable<TSource> ExceptBy<TSource, TKey>(this IEnumerable<TSource> first, IEnumerable<TKey> second, Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? comparer)
+    {
+        ArgumentNullException.ThrowIfNull(first);
+        ArgumentNullException.ThrowIfNull(second);
+        ArgumentNullException.ThrowIfNull(keySelector);
+        var set = new HashSet<TKey>(second, comparer);
+        return first.Where(item => set.Add(keySelector(item)));
+    }
+
+    /// <summary>
+    /// 添加多个元素
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="this"></param>
+    /// <param name="values"></param>
+    public static void AddRange<T>(this ICollection<T> @this, params T[] values)
+    {
+        foreach (var obj in values)
+        {
+            @this.Add(obj);
+        }
+    }
+
+    /// <summary>
+    /// 添加多个元素
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="this"></param>
+    /// <param name="values"></param>
+    public static void AddRange<T>(this ICollection<T> @this, IEnumerable<T> values)
+    {
+        foreach (var obj in values)
+        {
+            @this.Add(obj);
+        }
+    }
+
+    /// <summary>
+    /// 添加多个元素
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="this"></param>
+    /// <param name="values"></param>
+    public static void AddRange<T>(this ConcurrentBag<T> @this, params T[] values)
+    {
+        foreach (var obj in values)
+        {
+            @this.Add(obj);
+        }
+    }
+
+    /// <summary>
+    /// 添加多个元素
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="this"></param>
+    /// <param name="values"></param>
+    public static void AddRange<T>(this ConcurrentQueue<T> @this, params T[] values)
+    {
+        foreach (var obj in values)
+        {
+            @this.Enqueue(obj);
+        }
+    }
+
+    /// <summary>
+    /// 添加符合条件的多个元素
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="this"></param>
+    /// <param name="predicate"></param>
+    /// <param name="values"></param>
+    public static void AddRangeIf<T>(this ICollection<T> @this, Func<T, bool> predicate, params T[] values)
+    {
+        foreach (var obj in values)
+        {
+            if (predicate(obj))
+            {
+                @this.Add(obj);
+            }
+        }
+    }
+
+    /// <summary>
+    /// 添加符合条件的多个元素
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="this"></param>
+    /// <param name="predicate"></param>
+    /// <param name="values"></param>
+    public static void AddRangeIf<T>(this ConcurrentBag<T> @this, Func<T, bool> predicate, params T[] values)
+    {
+        foreach (var obj in values)
+        {
+            if (predicate(obj))
+            {
+                @this.Add(obj);
+            }
+        }
+    }
+
+    /// <summary>
+    /// 添加符合条件的多个元素
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="this"></param>
+    /// <param name="predicate"></param>
+    /// <param name="values"></param>
+    public static void AddRangeIf<T>(this ConcurrentQueue<T> @this, Func<T, bool> predicate, params T[] values)
+    {
+        foreach (var obj in values)
+        {
+            if (predicate(obj))
+            {
+                @this.Enqueue(obj);
+            }
+        }
+    }
+
+    /// <summary>
+    /// 添加不重复的元素
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="this"></param>
+    /// <param name="values"></param>
+    public static void AddRangeIfNotContains<T>(this ICollection<T> @this, params T[] values)
+    {
+        foreach (var obj in values)
+        {
+            if (!@this.Contains(obj))
+            {
+                @this.Add(obj);
+            }
+        }
+    }
+
+    /// <summary>
+    /// 移除符合条件的元素
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="this"></param>
+    /// <param name="where"></param>
+    public static void RemoveWhere<T>(this ICollection<T> @this, Func<T, bool> where)
+    {
+        foreach (var obj in @this.Where(where).ToList())
+        {
+            @this.Remove(obj);
+        }
+    }
+
+    /// <summary>
+    /// 在元素之后添加元素
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="list"></param>
+    /// <param name="condition">条件</param>
+    /// <param name="value">值</param>
+    public static void InsertAfter<T>(this IList<T> list, Func<T, bool> condition, T value)
+    {
+        foreach (var item in list.Select((item, index) => new
+                 {
+                     item,
+                     index
+                 }).Where(p => condition(p.item)).OrderByDescending(p => p.index))
+        {
+            if (item.index + 1 == list.Count)
+            {
+                list.Add(value);
+            }
+            else
+            {
+                list.Insert(item.index + 1, value);
+            }
+        }
+    }
+
+    /// <summary>
+    /// 在元素之后添加元素
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="list"></param>
+    /// <param name="index">索引位置</param>
+    /// <param name="value">值</param>
+    public static void InsertAfter<T>(this IList<T> list, int index, T value)
+    {
+        foreach (var item in list.Select((v, i) => new
+                 {
+                     Value = v,
+                     Index = i
+                 }).Where(p => p.Index == index).OrderByDescending(p => p.Index))
+        {
+            if (item.Index + 1 == list.Count)
+            {
+                list.Add(value);
+            }
+            else
+            {
+                list.Insert(item.Index + 1, value);
+            }
+        }
+    }
+
+    /// <summary>
+    /// 转HashSet
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <typeparam name="TResult"></typeparam>
+    /// <param name="source"></param>
+    /// <param name="selector"></param>
+    /// <returns></returns>
+    public static HashSet<TResult> ToHashSet<T, TResult>(this IEnumerable<T> source, Func<T, TResult> selector)
+    {
+        var set = new HashSet<TResult>();
+        set.UnionWith(source.Select(selector));
+        return set;
+    }
+
+    /// <summary>
+    /// 遍历IEnumerable
+    /// </summary>
+    /// <param name="ts"></param>
+    /// <param name="action">回调方法</param>
+    /// <typeparam name="T"></typeparam>
+    public static void ForEach<T>(this IEnumerable<T> ts, Action<T> action)
+    {
+        foreach (var o in ts)
+        {
+            action(o);
+        }
+    }
+
+    /// <summary>
+    /// 异步foreach
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="source"></param>
+    /// <param name="maxParallelCount">最大并行数</param>
+    /// <param name="action"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public static async Task ForeachAsync<T>(this IEnumerable<T> source, Func<T, Task> action, int maxParallelCount, CancellationToken cancellationToken = default)
+    {
+        if (Debugger.IsAttached)
+        {
+            foreach (var item in source)
+            {
+                await action(item);
+            }
+            return;
+        }
+        var list = new List<Task>();
+        foreach (var item in source)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+            list.Add(action(item));
+            if (list.Count(t => !t.IsCompleted) < maxParallelCount) continue;
+            {
+                await Task.WhenAny(list);
+                list.RemoveAll(t => t.IsCompleted);
+            }
+        }
+        await Task.WhenAll(list);
+    }
+
+    /// <summary>
+    /// 异步foreach
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="source"></param>
+    /// <param name="action"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public static Task ForeachAsync<T>(this IEnumerable<T> source, Func<T, Task> action, CancellationToken cancellationToken = default)
+    {
+        if (source is ICollection<T> collection)
+        {
+            return collection.ForeachAsync(action, collection.Count, cancellationToken);
+        }
+        var list = source.ToList();
+        return list.ForeachAsync(action, list.Count, cancellationToken);
+    }
+
+    /// <summary>
+    /// 异步Select
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <typeparam name="TResult"></typeparam>
+    /// <param name="source"></param>
+    /// <param name="selector"></param>
+    /// <returns></returns>
+    public static Task<TResult[]> SelectAsync<T, TResult>(this IEnumerable<T> source, Func<T, Task<TResult>> selector) => Task.WhenAll(source.Select(selector));
+
+    /// <summary>
+    /// 异步Select
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <typeparam name="TResult"></typeparam>
+    /// <param name="source"></param>
+    /// <param name="selector"></param>
+    /// <returns></returns>
+    public static Task<TResult[]> SelectAsync<T, TResult>(this IEnumerable<T> source, Func<T, int, Task<TResult>> selector) => Task.WhenAll(source.Select(selector));
+
+    /// <summary>
+    /// 异步Select
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <typeparam name="TResult"></typeparam>
+    /// <param name="source"></param>
+    /// <param name="selector"></param>
+    /// <param name="maxParallelCount">最大并行数</param>
+    /// <returns></returns>
+    public static async Task<List<TResult>> SelectAsync<T, TResult>(this IEnumerable<T> source, Func<T, Task<TResult>> selector, int maxParallelCount)
+    {
+        var results = new List<TResult>();
+        var tasks = new List<Task<TResult>>();
+        foreach (var item in source)
+        {
+            var task = selector(item);
+            tasks.Add(task);
+            if (tasks.Count < maxParallelCount) continue;
+            await Task.WhenAny(tasks);
+            var completedTasks = tasks.Where(t => t.IsCompleted).ToArray();
+            results.AddRange(completedTasks.Select(t => t.Result));
+            tasks.RemoveWhere(t => completedTasks.Contains(t));
+        }
+        results.AddRange(await Task.WhenAll(tasks));
+        return results;
+    }
+
+    /// <summary>
+    /// 异步Select
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <typeparam name="TResult"></typeparam>
+    /// <param name="source"></param>
+    /// <param name="selector"></param>
+    /// <param name="maxParallelCount">最大并行数</param>
+    /// <returns></returns>
+    public static async Task<List<TResult>> SelectAsync<T, TResult>(this IEnumerable<T> source, Func<T, int, Task<TResult>> selector, int maxParallelCount)
+    {
+        var results = new List<TResult>();
+        var tasks = new List<Task<TResult>>();
+        var index = 0;
+        foreach (var item in source)
+        {
+            var task = selector(item, index);
+            tasks.Add(task);
+            Interlocked.Add(ref index, 1);
+            if (tasks.Count < maxParallelCount) continue;
+            await Task.WhenAny(tasks);
+            var completedTasks = tasks.Where(t => t.IsCompleted).ToArray();
+            results.AddRange(completedTasks.Select(t => t.Result));
+            tasks.RemoveWhere(t => completedTasks.Contains(t));
+        }
+        results.AddRange(await Task.WhenAll(tasks));
+        return results;
+    }
+
+    /// <summary>
+    /// 异步For
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="source"></param>
+    /// <param name="selector"></param>
+    /// <param name="maxParallelCount">最大并行数</param>
+    /// <param name="cancellationToken">取消口令</param>
+    /// <returns></returns>
+    public static async Task ForAsync<T>(this IEnumerable<T> source, Func<T, int, Task> selector, int maxParallelCount, CancellationToken cancellationToken = default)
+    {
+        var index = 0;
+        if (Debugger.IsAttached)
+        {
+            foreach (var item in source)
+            {
+                await selector(item, index);
+                index++;
+            }
+            return;
+        }
+        var list = new List<Task>();
+        foreach (var item in source)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+            list.Add(selector(item, index));
+            Interlocked.Add(ref index, 1);
+            if (list.Count < maxParallelCount) continue;
+            await Task.WhenAny(list);
+            list.RemoveAll(t => t.IsCompleted);
+        }
+        await Task.WhenAll(list);
+    }
+
+    /// <summary>
+    /// 异步For
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="source"></param>
+    /// <param name="selector"></param>
+    /// <param name="cancellationToken">取消口令</param>
+    /// <returns></returns>
+    public static Task ForAsync<T>(this IEnumerable<T> source, Func<T, int, Task> selector, CancellationToken cancellationToken = default)
+    {
+        if (source is ICollection<T> collection)
+        {
+            return collection.ForAsync(selector, collection.Count, cancellationToken);
+        }
+        var list = source.ToList();
+        return list.ForAsync(selector, list.Count, cancellationToken);
+    }
+
+    /// <summary>
+    /// 取最大值
+    /// </summary>
+    /// <typeparam name="TSource"></typeparam>
+    /// <typeparam name="TResult"></typeparam>
+    /// <param name="source"></param>
+    /// <param name="selector"></param>
+    /// <returns></returns>
+    public static TResult? MaxOrDefault<TSource, TResult>(this IQueryable<TSource> source, Expression<Func<TSource, TResult>> selector) => source.Select(selector).DefaultIfEmpty().Max();
+
+    /// <summary>
+    /// 取最大值
+    /// </summary>
+    /// <typeparam name="TSource"></typeparam>
+    /// <typeparam name="TResult"></typeparam>
+    /// <param name="source"></param>
+    /// <param name="selector"></param>
+    /// <param name="defaultValue"></param>
+    /// <returns></returns>
+    public static TResult? MaxOrDefault<TSource, TResult>(this IQueryable<TSource> source, Expression<Func<TSource, TResult>> selector, TResult defaultValue) => source.Select(selector).DefaultIfEmpty(defaultValue).Max();
+
+    /// <summary>
+    /// 取最大值
+    /// </summary>
+    /// <typeparam name="TSource"></typeparam>
+    /// <param name="source"></param>
+    /// <returns></returns>
+    public static TSource? MaxOrDefault<TSource>(this IQueryable<TSource> source) => source.DefaultIfEmpty().Max();
+
+    /// <summary>
+    /// 取最大值
+    /// </summary>
+    /// <typeparam name="TSource"></typeparam>
+    /// <param name="source"></param>
+    /// <param name="defaultValue"></param>
+    /// <returns></returns>
+    public static TSource? MaxOrDefault<TSource>(this IQueryable<TSource> source, TSource defaultValue) => source.DefaultIfEmpty(defaultValue).Max();
+
+    /// <summary>
+    /// 取最大值
+    /// </summary>
+    /// <typeparam name="TSource"></typeparam>
+    /// <typeparam name="TResult"></typeparam>
+    /// <param name="source"></param>
+    /// <param name="selector"></param>
+    /// <param name="defaultValue"></param>
+    /// <returns></returns>
+    public static TResult? MaxOrDefault<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, TResult> selector, TResult defaultValue) => source.Select(selector).DefaultIfEmpty(defaultValue).Max();
+
+    /// <summary>
+    /// 取最大值
+    /// </summary>
+    /// <typeparam name="TSource"></typeparam>
+    /// <typeparam name="TResult"></typeparam>
+    /// <param name="source"></param>
+    /// <param name="selector"></param>
+    /// <returns></returns>
+    public static TResult? MaxOrDefault<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, TResult> selector) => source.Select(selector).DefaultIfEmpty().Max();
+
+    /// <summary>
+    /// 取最大值
+    /// </summary>
+    /// <typeparam name="TSource"></typeparam>
+    /// <param name="source"></param>
+    /// <returns></returns>
+    public static TSource? MaxOrDefault<TSource>(this IEnumerable<TSource> source) => source.DefaultIfEmpty().Max();
+
+    /// <summary>
+    /// 取最大值
+    /// </summary>
+    /// <typeparam name="TSource"></typeparam>
+    /// <param name="source"></param>
+    /// <param name="defaultValue"></param>
+    /// <returns></returns>
+    public static TSource? MaxOrDefault<TSource>(this IEnumerable<TSource> source, TSource defaultValue) => source.DefaultIfEmpty(defaultValue).Max();
+
+    /// <summary>
+    /// 取最小值
+    /// </summary>
+    /// <typeparam name="TSource"></typeparam>
+    /// <typeparam name="TResult"></typeparam>
+    /// <param name="source"></param>
+    /// <param name="selector"></param>
+    /// <returns></returns>
+    public static TResult? MinOrDefault<TSource, TResult>(this IQueryable<TSource> source, Expression<Func<TSource, TResult>> selector) => source.Select(selector).DefaultIfEmpty().Min();
+
+    /// <summary>
+    /// 取最小值
+    /// </summary>
+    /// <typeparam name="TSource"></typeparam>
+    /// <typeparam name="TResult"></typeparam>
+    /// <param name="source"></param>
+    /// <param name="selector"></param>
+    /// <param name="defaultValue"></param>
+    /// <returns></returns>
+    public static TResult? MinOrDefault<TSource, TResult>(this IQueryable<TSource> source, Expression<Func<TSource, TResult>> selector, TResult defaultValue) => source.Select(selector).DefaultIfEmpty(defaultValue).Min();
+
+    /// <summary>
+    /// 取最小值
+    /// </summary>
+    /// <typeparam name="TSource"></typeparam>
+    /// <param name="source"></param>
+    /// <returns></returns>
+    public static TSource? MinOrDefault<TSource>(this IQueryable<TSource> source) => source.DefaultIfEmpty().Min();
+
+    /// <summary>
+    /// 取最小值
+    /// </summary>
+    /// <typeparam name="TSource"></typeparam>
+    /// <param name="source"></param>
+    /// <param name="defaultValue"></param>
+    /// <returns></returns>
+    public static TSource? MinOrDefault<TSource>(this IQueryable<TSource> source, TSource defaultValue) => source.DefaultIfEmpty(defaultValue).Min();
+
+    /// <summary>
+    /// 取最小值
+    /// </summary>
+    /// <typeparam name="TSource"></typeparam>
+    /// <typeparam name="TResult"></typeparam>
+    /// <param name="source"></param>
+    /// <param name="selector"></param>
+    /// <returns></returns>
+    public static TResult? MinOrDefault<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, TResult> selector) => source.Select(selector).DefaultIfEmpty().Min();
+
+    /// <summary>
+    /// 取最小值
+    /// </summary>
+    /// <typeparam name="TSource"></typeparam>
+    /// <typeparam name="TResult"></typeparam>
+    /// <param name="source"></param>
+    /// <param name="selector"></param>
+    /// <param name="defaultValue"></param>
+    /// <returns></returns>
+    public static TResult? MinOrDefault<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, TResult> selector, TResult defaultValue) => source.Select(selector).DefaultIfEmpty(defaultValue).Min();
+
+    /// <summary>
+    /// 取最小值
+    /// </summary>
+    /// <typeparam name="TSource"></typeparam>
+    /// <param name="source"></param>
+    /// <returns></returns>
+    public static TSource? MinOrDefault<TSource>(this IEnumerable<TSource> source) => source.DefaultIfEmpty().Min();
+
+    /// <summary>
+    /// 取最小值
+    /// </summary>
+    /// <typeparam name="TSource"></typeparam>
+    /// <param name="source"></param>
+    /// <param name="defaultValue"></param>
+    /// <returns></returns>
+    public static TSource? MinOrDefault<TSource>(this IEnumerable<TSource> source, TSource defaultValue) => source.DefaultIfEmpty(defaultValue).Min();
+    /// <summary>
+    /// 标准差
+    /// </summary>
+    /// <param name="source"></param>
+    /// <returns></returns>
+    public static double StandardDeviation(this IEnumerable<double> source)
+    {
+        double result = 0;
+        var list = source as ICollection<double> ?? source.ToList();
+        var count = list.Count;
+        if (count <= 1) return result;
+        var avg = list.Average();
+        var sum = list.Sum(d => (d - avg) * (d - avg));
+        result = Math.Sqrt(sum / count);
+        return result;
+    }
+
+    /// <summary>
+    /// 随机排序
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="source"></param>
+    /// <returns></returns>
+    public static IOrderedEnumerable<T> OrderByRandom<T>(this IEnumerable<T> source)
+    {
+        return source.OrderBy(_ => Guid.NewGuid());
+    }
+
+    /// <summary>
+    /// 序列相等
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="first"></param>
+    /// <param name="second"></param>
+    /// <param name="condition"></param>
+    /// <returns></returns>
+    public static bool SequenceEqual<T>(this IEnumerable<T> first, IEnumerable<T> second, Func<T, T, bool> condition)
+    {
+        if (first is ICollection<T> source1 && second is ICollection<T> source2)
+        {
+            if (source1.Count != source2.Count)
+            {
+                return false;
+            }
+            if (source1 is IList<T> list1 && source2 is IList<T> list2)
+            {
+                var count = source1.Count;
+                for (var index = 0; index < count; ++index)
+                {
+                    if (!condition(list1[index], list2[index]))
+                    {
+                        return false;
+                    }
+                }
+                return true;
+            }
+        }
+        using var enumerator1 = first.GetEnumerator();
+        using var enumerator2 = second.GetEnumerator();
+        while (enumerator1.MoveNext())
+        {
+            if (!enumerator2.MoveNext() || !condition(enumerator1.Current, enumerator2.Current))
+            {
+                return false;
+            }
+        }
+        return !enumerator2.MoveNext();
+    }
+
+    /// <summary>
+    /// 序列相等
+    /// </summary>
+    /// <typeparam name="T1"></typeparam>
+    /// <typeparam name="T2"></typeparam>
+    /// <param name="first"></param>
+    /// <param name="second"></param>
+    /// <param name="condition"></param>
+    /// <returns></returns>
+    public static bool SequenceEqual<T1, T2>(this IEnumerable<T1> first, IEnumerable<T2> second, Func<T1, T2, bool> condition)
+    {
+        if (first is ICollection<T1> source1 && second is ICollection<T2> source2)
+        {
+            if (source1.Count != source2.Count)
+            {
+                return false;
+            }
+            if (source1 is IList<T1> list1 && source2 is IList<T2> list2)
+            {
+                var count = source1.Count;
+                for (var index = 0; index < count; ++index)
+                {
+                    if (!condition(list1[index], list2[index]))
+                    {
+                        return false;
+                    }
+                }
+                return true;
+            }
+        }
+        using var enumerator1 = first.GetEnumerator();
+        using var enumerator2 = second.GetEnumerator();
+        while (enumerator1.MoveNext())
+        {
+            if (!enumerator2.MoveNext() || !condition(enumerator1.Current, enumerator2.Current))
+            {
+                return false;
+            }
+        }
+        return !enumerator2.MoveNext();
+    }
+
+    /// <summary>
+    /// 对比两个集合哪些是新增的、删除的、修改的
+    /// </summary>
+    /// <typeparam name="T1"></typeparam>
+    /// <typeparam name="T2"></typeparam>
+    /// <param name="first"></param>
+    /// <param name="second"></param>
+    /// <param name="condition">对比因素条件</param>
+    /// <returns></returns>
+    public static (List<T1> adds, List<T2> remove, List<T1> updates) CompareChanges<T1, T2>(this IEnumerable<T1>? first, IEnumerable<T2>? second, Func<T1, T2, bool> condition)
+    {
+        first ??= new List<T1>();
+        second ??= new List<T2>();
+        var firstSource = first as ICollection<T1> ?? first.ToList();
+        var secondSource = second as ICollection<T2> ?? second.ToList();
+        var add = firstSource.ExceptBy(secondSource, condition).ToList();
+        var remove = secondSource.ExceptBy(firstSource, (s, f) => condition(f, s)).ToList();
+        var update = firstSource.IntersectBy(secondSource, condition).ToList();
+        return (add, remove, update);
+    }
+    
+    /// <summary>
+    /// 将集合声明为非null集合
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="list"></param>
+    /// <returns></returns>
+    public static IEnumerable<T> AsNotNull<T>(this IEnumerable<T>? list) => list ?? new List<T>();
+
+    /// <summary>
+    /// 满足条件时执行筛选条件
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="source"></param>
+    /// <param name="condition"></param>
+    /// <param name="where"></param>
+    /// <returns></returns>
+    public static IEnumerable<T> WhereIf<T>(this IEnumerable<T> source, bool condition, Func<T, bool> where) => condition ? source.Where(where) : source;
+
+    /// <summary>
+    /// 满足条件时执行筛选条件
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="source"></param>
+    /// <param name="condition"></param>
+    /// <param name="where"></param>
+    /// <returns></returns>
+    public static IEnumerable<T> WhereIf<T>(this IEnumerable<T> source, Func<bool> condition, Func<T, bool> where) => condition() ? source.Where(where) : source;
+
+    /// <summary>
+    /// 满足条件时执行筛选条件
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="source"></param>
+    /// <param name="condition"></param>
+    /// <param name="where"></param>
+    /// <returns></returns>
+    public static IQueryable<T> WhereIf<T>(this IQueryable<T> source, bool condition, Expression<Func<T, bool>> where) => condition ? source.Where(where) : source;
+
+    /// <summary>
+    /// 满足条件时执行筛选条件
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="source"></param>
+    /// <param name="condition"></param>
+    /// <param name="where"></param>
+    /// <returns></returns>
+    public static IQueryable<T> WhereIf<T>(this IQueryable<T> source, Func<bool> condition, Expression<Func<T, bool>> where) => condition() ? source.Where(where) : source;
+
+    /// <summary>
+    /// 改变元素的索引位置
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="list">集合</param>
+    /// <param name="item">元素</param>
+    /// <param name="index">索引值</param>
+    /// <exception cref="ArgumentNullException"></exception>
+    public static IList<T> ChangeIndex<T>(this IList<T> list, T item, int index)
+    {
+        if (item is null)
+        {
+            throw new ArgumentNullException(nameof(item));
+        }
+        ChangeIndexInternal(list, item, index);
+        return list;
+    }
+
+    /// <summary>
+    /// 改变元素的索引位置
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="list">集合</param>
+    /// <param name="condition">元素定位条件</param>
+    /// <param name="index">索引值</param>
+    public static IList<T> ChangeIndex<T>(this IList<T> list, Func<T, bool> condition, int index)
+    {
+        var item = list.FirstOrDefault(condition);
+        if (item != null)
+        {
+            ChangeIndexInternal(list, item, index);
+        }
+        return list;
+    }
+
+    private static void ChangeIndexInternal<T>(IList<T> list, T item, int index)
+    {
+        index = Math.Max(0, index);
+        index = Math.Min(list.Count - 1, index);
+        list.Remove(item);
+        list.Insert(index, item);
+    }
+
+    /// <summary>
+    /// 把集合转成SqlIn
+    /// </summary>
+    /// <typeparam name="TSource">源</typeparam>
+    /// <param name="values">要转换的值</param>
+    /// <param name="separator">分割符</param>
+    /// <param name="left">左边符</param>
+    /// <param name="right">右边符</param>
+    /// <returns>返回组装好的值，例如"'a','b'"</returns>
+    public static string ToSqlIn<TSource>(this IEnumerable<TSource> values, string separator = ",", string left = "'", string right = "'")
+    {
+        StringBuilder sb = new();
+        var enumerable = values as TSource[] ?? values.ToArray();
+        if (!enumerable.Any())
+        {
+            return string.Empty;
+        }
+        enumerable.ToList().ForEach(o => _ = sb.Append($"{left}{o}{right}{separator}"));
+        return sb.ToString().TrimEnd($"{separator}".ToCharArray());
+    }
+}

--- a/src/framework/Luck.Framework/Extensions/JsonExtension.cs
+++ b/src/framework/Luck.Framework/Extensions/JsonExtension.cs
@@ -51,11 +51,7 @@ namespace Luck.Framework.Extensions
         /// <returns></returns>
         public static T? Deserialize<T>(this string text)
         {
-            if (string.IsNullOrEmpty(text))
-            {
-                return default;
-            }
-            return JsonSerializer.Deserialize<T>(text);
+            return string.IsNullOrEmpty(text) ? default : JsonSerializer.Deserialize<T>(text);
         }
         /// <summary>
         /// 
@@ -66,11 +62,7 @@ namespace Luck.Framework.Extensions
         /// <returns></returns>
         public static T? Deserialize<T>(this string text, JsonSerializerOptions options)
         {
-            if (string.IsNullOrEmpty(text))
-            {
-                return default;
-            }
-            return JsonSerializer.Deserialize<T>(text, options);
+            return string.IsNullOrEmpty(text) ? default : JsonSerializer.Deserialize<T>(text, options);
         }
 
     }

--- a/src/framework/Luck.Framework/Infrastructure/Modules/IModuleApplication.cs
+++ b/src/framework/Luck.Framework/Infrastructure/Modules/IModuleApplication.cs
@@ -23,7 +23,7 @@ namespace Luck.Framework.Infrastructure
         /// <summary>
         /// 
         /// </summary>
-        IServiceProvider ServiceProvider { get; }
+        IServiceProvider? ServiceProvider { get; }
 
         /// <summary>
         /// 
@@ -32,6 +32,6 @@ namespace Luck.Framework.Infrastructure
         /// <summary>
         /// 
         /// </summary>
-        List<IAppModule> Source { get; }
+        IEnumerable<IAppModule> Source { get; }
     }
 }

--- a/src/framework/Luck.Framework/Infrastructure/Reflections/AssemblyHelper.cs
+++ b/src/framework/Luck.Framework/Infrastructure/Reflections/AssemblyHelper.cs
@@ -12,13 +12,16 @@ namespace Luck.Framework.Infrastructure
     {
         private static readonly string[] Filters = { "dotnet-", "Microsoft.", "mscorlib", "netstandard", "System", "Windows" };
 
+        // ReSharper disable once InconsistentNaming
         private static readonly IEnumerable<Assembly>? _allAssemblies;
+        // ReSharper disable once InconsistentNaming
         private static readonly IEnumerable<Type>? _allTypes;
         
         /// <summary>
         /// 需要排除的项目
         /// </summary>
-        private static readonly List<string> _filterLibs = new List<string>();
+        // ReSharper disable once InconsistentNaming
+        private static readonly List<string> _filterLibs = new();
         
         /// <summary>
         /// 构造函数

--- a/src/framework/Luck.Framework/Infrastructure/Reflections/AssemblyHelper.cs
+++ b/src/framework/Luck.Framework/Infrastructure/Reflections/AssemblyHelper.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.Extensions.DependencyModel;
-using System.Linq;
 using System.Reflection;
 using System.Runtime.Loader;
+using Luck.Framework.Extensions;
 
 namespace Luck.Framework.Infrastructure
 {
@@ -10,100 +10,63 @@ namespace Luck.Framework.Infrastructure
     /// </summary>
     public static class AssemblyHelper
     {
+        private static readonly string[] Filters = { "dotnet-", "Microsoft.", "mscorlib", "netstandard", "System", "Windows" };
+
+        private static readonly IEnumerable<Assembly>? _allAssemblies;
+        private static readonly IEnumerable<Type>? _allTypes;
+        
+        /// <summary>
+        /// 需要排除的项目
+        /// </summary>
+        private static readonly List<string> _filterLibs = new List<string>();
+        
+        /// <summary>
+        /// 构造函数
+        /// </summary>
+        static AssemblyHelper()
+        {
+            _allAssemblies = DependencyContext.Default?.GetDefaultAssemblyNames().Where(c => c.Name is not null && !Filters.Any(c.Name.StartsWith) && !_filterLibs.Any(c.Name.StartsWith)).Select(Assembly.Load);
+            _allTypes = _allAssemblies?.SelectMany(c => c.GetTypes());
+        }
+        
         /// <summary>
         /// 根据程序集名字得到程序集
+        /// Microsoft.DotNet.PlatformAbstractions.ApplicationEnvironment.ApplicationBasePath; //获取项目路径
         /// </summary>
         /// <param name="assemblyNames"></param>
         /// <returns></returns>
-        public static IEnumerable<Assembly> GetAssembliesByName(params string[] assemblyNames)
-        {
-            var basePath = Path.Combine(AppContext.BaseDirectory); //Microsoft.DotNet.PlatformAbstractions.ApplicationEnvironment.ApplicationBasePath; //获取项目路径
-            return assemblyNames.Select(o => AssemblyLoadContext.Default.LoadFromAssemblyPath(Path.Combine(basePath, $"{o}.dll")));
-        }
-
-        private static readonly string[] Filters = { "dotnet-", "Microsoft.", "mscorlib", "netstandard", "System", "Windows" };
-
-        private static Assembly[]? _allAssemblies;
-        private static Type[] _allTypes;
-
+        public static IEnumerable<Assembly> GetAssembliesByName(params string[] assemblyNames)=>
+            assemblyNames.Select(o => AssemblyLoadContext.Default.LoadFromAssemblyPath(Path.Combine(Path.Combine(AppContext.BaseDirectory), $"{o}.dll")));
+        
         /// <summary>
-        /// 获取 所有程序集
+        /// 添加排除项目,该排除项目可能会影响AutoDependenceInjection自动注入,请使用的时候自行测试.
         /// </summary>
-        public static Assembly[] AllAssemblies
-        {
-            get
-            {
-                if (_allAssemblies == null)
-                {
-                    Init();
-                }
-
-                return _allAssemblies;
-            }
-        }
-
-        /// <summary>
-        /// 获取 所有类型
-        /// </summary>
-        public static Type[] AllTypes
-        {
-            get
-            {
-                if (_allAssemblies == null)
-                {
-                    Init();
-                }
-
-                return _allTypes;
-            }
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        private static void Init()
-        {
-            _allAssemblies = DependencyContext.Default.GetDefaultAssemblyNames().Where(o => o.Name != null && !Filters.Any(o.Name.StartsWith)).Select(Assembly.Load).ToArray();
-            _allTypes = _allAssemblies.SelectMany(m => m.GetTypes()).ToArray();
-        }
-
+        /// <param name="names"></param>
+        public static void AddExcludeLibs(params string[] names) => _filterLibs.AddRangeIfNotContains(names);
+        
         /// <summary>
         /// 查找指定条件的类型
         /// </summary>
-        public static Type[] FindTypes(Func<Type, bool> predicate)
-        {
-            return AllTypes.Where(predicate).ToArray();
-        }
-
+        public static IEnumerable<Type> FindTypes(Func<Type, bool> predicate)=>_allTypes!.Where(predicate).ToArray();
+        
         /// <summary>
         /// 
         /// </summary>
         /// <typeparam name="TAttribute"></typeparam>
         /// <returns></returns>
-        public static Type[] FindTypesByAttribute<TAttribute>()
-
-        {
-            var attributeType = typeof(TAttribute);
-            return FindTypesByAttribute(attributeType);
-        }
-
-
+        public static Type[] FindTypesByAttribute<TAttribute>() where TAttribute : Attribute => FindTypesByAttribute(typeof(TAttribute));
+        
         /// <summary>
         /// 
         /// </summary>
         /// <param name="type"></param>
         /// <returns></returns>
-        private static Type[] FindTypesByAttribute(Type type)
-        {
-            return AllTypes.Where(a => a.IsDefined(type, true)).Distinct().ToArray();
-        }
-
+        private static Type[] FindTypesByAttribute(Type type)=> _allTypes!.Where(a => a.IsDefined(type, true)).Distinct().ToArray();
+        
         /// <summary>
         /// 查找指定条件的类型
         /// </summary>
-        public static Assembly[] FindAllItems(Func<Assembly, bool> predicate)
-        {
-            return AllAssemblies.Where(predicate).ToArray();
-        }
+        public static Assembly[] FindAllItems(Func<Assembly, bool> predicate)=> _allAssemblies!.Where(predicate).ToArray();
+        
     }
 }

--- a/src/framework/Luck.Framework/Luck.Framework.csproj
+++ b/src/framework/Luck.Framework/Luck.Framework.csproj
@@ -11,7 +11,6 @@
 		<PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
 	</ItemGroup>
 	<ItemGroup  Condition="'$(TargetFramework)' == 'net7.0'">
-		
 		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />

--- a/src/framework/Luck.Framework/Luck.Framework.csproj
+++ b/src/framework/Luck.Framework/Luck.Framework.csproj
@@ -20,7 +20,6 @@
 		<PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="7.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
 		<PackageReference Include="Microsoft.Extensions.Options" Version="7.0.1" />
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
 	</ItemGroup>
 	<ItemGroup  Condition="'$(TargetFramework)' == 'net8.0'">
 		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0-rc.2.23479.6" />
@@ -31,9 +30,7 @@
 		<PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="8.0.0-rc.2.23479.6" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0-rc.2.23479.6" />
 		<PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0-rc.2.23479.6" />
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0-rc.2.23479.6" />
 	</ItemGroup>
-
 	<ItemGroup>
 	<PackageReference Include="JetBrains.Annotations" Version="2022.1.0" />
 	</ItemGroup>

--- a/src/framework/Luck.Framework/Luck.Framework.csproj
+++ b/src/framework/Luck.Framework/Luck.Framework.csproj
@@ -1,24 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<Import Project="..\..\common.props" />
-	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<Nullable>enable</Nullable>
-
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-		<TreatWarningsAsErrors>False</TreatWarningsAsErrors>
-		<NoWarn>1701;1702;8618;8603</NoWarn>
-	</PropertyGroup>
-
-
-	<ItemGroup>
-		<Folder Include="Infrastructure\Excel\" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<PackageReference Include="JetBrains.Annotations" Version="2022.1.0" />
+	<ItemGroup  Condition="'$(TargetFramework)' == 'net6.0'">
 		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
@@ -27,11 +9,32 @@
 		<PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.2" />
 		<PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
+	</ItemGroup>
+	<ItemGroup  Condition="'$(TargetFramework)' == 'net7.0'">
+		
+		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyModel" Version="7.0.0" />
+		<PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" Version="7.0.0" />
+		<PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="7.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Options" Version="7.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
+	</ItemGroup>
+	<ItemGroup  Condition="'$(TargetFramework)' == 'net8.0'">
+		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0-rc.2.23479.6" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0-rc.2.23479.6" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0-rc.2.23479.6" />
+		<PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.0-rc.2.23479.6" />
+		<PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" Version="8.0.0-rc.2.23479.6" />
+		<PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="8.0.0-rc.2.23479.6" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0-rc.2.23479.6" />
+		<PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0-rc.2.23479.6" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0-rc.2.23479.6" />
 	</ItemGroup>
 
 	<ItemGroup>
-		<None Remove="Infrastructure\DependencyInjectionPropertyInjection\PropertyInjectionServiceProvider.cs~RFecffbcd.TMP" />
-		<None Remove="Microsoft.Extensions.Hosting" />
+	<PackageReference Include="JetBrains.Annotations" Version="2022.1.0" />
 	</ItemGroup>
 </Project>

--- a/src/framework/Luck.Framework/Utilities/Check.cs
+++ b/src/framework/Luck.Framework/Utilities/Check.cs
@@ -1,8 +1,5 @@
-﻿using JetBrains.Annotations;
-using Luck.Framework.Extensions;
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
+﻿using Luck.Framework.Extensions;
+
 
 namespace Luck.Framework.Utilities
 {

--- a/src/framework/Luck.MongoDB/DbContexts/MongoDbContextBase.cs
+++ b/src/framework/Luck.MongoDB/DbContexts/MongoDbContextBase.cs
@@ -7,13 +7,11 @@ namespace Luck.MongoDB.DbContexts
 {
     public abstract class MongoDbContextBase : IMongoDbContext
     {
-
-
         private readonly MongoContextOptions _options;
 
-        protected const string DefaultDatabaseName = "Luck";
+        private const string DefaultDatabaseName = "Luck";
 
-        public MongoDbContextBase([NotNull] MongoContextOptions options)
+        protected MongoDbContextBase([NotNull] MongoContextOptions options)
         {
             _options = options;
             _connectionString = Check.NotNullOrEmpty(_options.ConnectionString, nameof(options.ConnectionString));
@@ -28,6 +26,11 @@ namespace Luck.MongoDB.DbContexts
         public virtual IMongoCollection<TEntity> Collection<TEntity>()
         {
             return Database.GetCollection<TEntity>(GetTableName<TEntity>());
+        }
+        
+        public virtual IMongoCollection<TEntity> Collection<TEntity>(string tableName)
+        {
+            return Database.GetCollection<TEntity>(tableName);
         }
 
         //public virtual IMongoCollection<TEntity> Collection<TEntity>(string tableName)

--- a/src/framework/Luck.MongoDB/Luck.MongoDB.csproj
+++ b/src/framework/Luck.MongoDB/Luck.MongoDB.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <Import Project="..\..\common.props" />
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/src/framework/Luck.MongoDB/Luck.MongoDB.csproj
+++ b/src/framework/Luck.MongoDB/Luck.MongoDB.csproj
@@ -11,8 +11,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="MongoDB.Bson" Version="2.19.0" />
-      <PackageReference Include="MongoDB.Driver" Version="2.19.0" />
+      <PackageReference Include="MongoDB.Bson" Version="2.22.0" />
+      <PackageReference Include="MongoDB.Driver" Version="2.22.0" />
     </ItemGroup>
 
 </Project>

--- a/src/framework/Luck.Redis.StackExchange/Luck.Redis.StackExchange.csproj
+++ b/src/framework/Luck.Redis.StackExchange/Luck.Redis.StackExchange.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="StackExchange.Redis" Version="2.6.70" />
+        <PackageReference Include="StackExchange.Redis" Version="2.6.122" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/framework/Luck.Redis.StackExchange/Luck.Redis.StackExchange.csproj
+++ b/src/framework/Luck.Redis.StackExchange/Luck.Redis.StackExchange.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <Import Project="..\..\common.props" />
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/src/framework/Luck.TestBase/IntegratedTest.cs
+++ b/src/framework/Luck.TestBase/IntegratedTest.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Luck.AppModule;
+using Luck.AutoDependencyInjection;
 
 namespace Luck.TestBase
 {

--- a/src/framework/Luck.TestBase/Luck.TestBase.csproj
+++ b/src/framework/Luck.TestBase/Luck.TestBase.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <Import Project="..\..\common.props" />
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/src/framework/Luck.TestBase/Luck.TestBase.csproj
+++ b/src/framework/Luck.TestBase/Luck.TestBase.csproj
@@ -7,6 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\Luck.AutoDependencyInjection\Luck.AutoDependencyInjection.csproj" />
         <ProjectReference Include="..\Luck.Dapper.ClickHouse\Luck.Dapper.ClickHouse.csproj" />
         <ProjectReference Include="..\Luck.Framework\Luck.Framework.csproj" />
     </ItemGroup>

--- a/test/Luck.UnitTest/ClickHouse_Tests/ClickHouseTest.cs
+++ b/test/Luck.UnitTest/ClickHouse_Tests/ClickHouseTest.cs
@@ -3,7 +3,6 @@ using System.Data;
 using Luck.Dapper.DbConnectionFactories;
 using Luck.TestBase;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -21,7 +20,6 @@ public class ClickHouseTest : IntegratedTest<ClickHouseTestModule>
     [Fact]
     public void Connection_Test_Open()
     {
-        var hostEnvironment = ServiceProvider.GetService<IHostEnvironment>();
         var dbConnectionFactory = ServiceProvider.GetService<IDapperDrivenProvider>();
         if (dbConnectionFactory is null)
             throw new ArgumentNullException(nameof(dbConnectionFactory));

--- a/test/Luck.UnitTest/Luck.UnitTest.csproj
+++ b/test/Luck.UnitTest/Luck.UnitTest.csproj
@@ -12,6 +12,8 @@
 
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
 
+        <PackageReference Include="Mongo2Go" Version="3.1.3" />
+
         <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/Luck.UnitTest/Luck.UnitTest.csproj
+++ b/test/Luck.UnitTest/Luck.UnitTest.csproj
@@ -11,7 +11,6 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
 
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-        <PackageReference Include="MongoDB.Driver" Version="2.19.0" />
 
         <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
@@ -25,7 +24,7 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-        <PackageReference Include="MongoDB.Driver" Version="2.19.0" />
+        <PackageReference Include="MongoDB.Driver" Version="2.22.0" />
         <ProjectReference Include="..\..\src\framework\Luck.MongoDB\Luck.MongoDB.csproj" />
         <ProjectReference Include="..\..\src\framework\Luck.TestBase\Luck.TestBase.csproj" />
     </ItemGroup>

--- a/test/Luck.UnitTest/MongoDbTests/MongoDbTestModule.cs
+++ b/test/Luck.UnitTest/MongoDbTests/MongoDbTestModule.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using Luck.AppModule;
+using Luck.Framework.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Mongo2Go;
+
+namespace Luck.UnitTest.MongoDbTests;
+
+/// <summary>
+/// 
+/// </summary>
+public class MongoDbTestModule : LuckAppModule,IDisposable
+{
+    private readonly MongoDbRunner _runner = MongoDbRunner.Start();
+
+    public override void ConfigureServices(ConfigureServicesContext context)
+    {
+        context.Services.AddMongoDbContext<TestMongoDbMemoryDataBaseContext>(options =>
+        {
+            options.ConnectionString =_runner.ConnectionString;
+        });
+    }
+    
+    public void Dispose()
+    {
+        _runner.Dispose();
+    }
+}

--- a/test/Luck.UnitTest/MongoDbTests/Order.cs
+++ b/test/Luck.UnitTest/MongoDbTests/Order.cs
@@ -1,0 +1,11 @@
+namespace Luck.UnitTest.MongoDbTests;
+
+public class Order
+{
+
+    public string Id { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public int Number { get; set; }
+
+
+}

--- a/test/Luck.UnitTest/MongoDbTests/TestMongoDbMemoryDataBase.cs
+++ b/test/Luck.UnitTest/MongoDbTests/TestMongoDbMemoryDataBase.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Threading.Tasks;
+using Luck.TestBase;
+using Xunit;
+using Microsoft.Extensions.DependencyInjection;
+using MongoDB.Driver;
+
+namespace Luck.UnitTest.MongoDbTests;
+
+public class TestMongoDbMemoryDataBase : IntegratedTest<MongoDbTestModule>
+{
+    
+    [Fact]
+    public  async Task Connection_Test_Open()
+    {
+        var id = Guid.NewGuid().ToString();
+        var testMongoDbMemoryDataBaseContext = ServiceProvider.GetService<TestMongoDbMemoryDataBaseContext>();
+        if (testMongoDbMemoryDataBaseContext is null)
+            throw new ArgumentNullException(nameof(testMongoDbMemoryDataBaseContext));
+        await  testMongoDbMemoryDataBaseContext.Orders.InsertOneAsync(new Order()
+        {
+            Id = id,
+            Name = "A002",
+            Number = 10,
+        });
+        var result = await testMongoDbMemoryDataBaseContext.Orders.Find(x => x.Id == id).SingleOrDefaultAsync();
+    }
+    
+}

--- a/test/Luck.UnitTest/MongoDbTests/TestMongoDbMemoryDataBaseContext.cs
+++ b/test/Luck.UnitTest/MongoDbTests/TestMongoDbMemoryDataBaseContext.cs
@@ -1,0 +1,20 @@
+﻿using JetBrains.Annotations;
+using Luck.MongoDB;
+using Luck.MongoDB.DbContexts;
+using MongoDB.Driver;
+
+namespace Luck.UnitTest.MongoDbTests;
+
+public class TestMongoDbMemoryDataBaseContext : MongoDbContextBase
+{
+    public TestMongoDbMemoryDataBaseContext([NotNull] MongoContextOptions options) : base(options)
+    {
+
+    }
+    /// <summary>
+    /// MongoTest
+    /// </summary>
+    public IMongoCollection<Order> Orders => Collection<Order>("orders");
+    
+    
+}

--- a/test/Luck.UnitTest/Pipeline/ContextBase.cs
+++ b/test/Luck.UnitTest/Pipeline/ContextBase.cs
@@ -1,0 +1,14 @@
+namespace Luck.UnitTest.Pipeline;
+
+public class ContextBase<TRequest, TResponse>
+{
+    /// <summary>
+    /// 请求
+    /// </summary>
+    public TRequest Request { get; set; } = default!;
+
+    /// <summary>
+    /// 响应
+    /// </summary>
+    public TResponse Response { get; set; } = default!;
+}

--- a/test/Luck.UnitTest/Pipeline/DefaultPipelineBuilder.cs
+++ b/test/Luck.UnitTest/Pipeline/DefaultPipelineBuilder.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Luck.UnitTest.Pipeline;
+
+public class DefaultPipelineBuilder<TContext> : IPipelineBuilder<TContext> where TContext : class
+{
+    private  IList<PipeDelegate<TContext>> _pipes = new List<PipeDelegate<TContext>>();
+    
+    public IPipelineBuilder<TContext> UsePipe(IPipe<TContext> pipe)
+    {
+        // 将pipe包装成获取责任链的回调
+        PipeDelegate<TContext> pipeDelegate = next => context => pipe.InvokeAsync(context, next);
+        if (pipeDelegate == null)
+        {
+            throw new ArgumentNullException(nameof(pipeDelegate));
+        }
+        _pipes.Add(pipeDelegate);
+
+        return this;
+    }
+
+    /// <summary>
+    /// <see cref="IPipelineBuilder{TContext}.Build"/>
+    /// </summary>
+    /// <returns></returns>
+    public HandlerDelegate<TContext> Build()
+    {
+        // 默认最后一个是个空执行
+        HandlerDelegate<TContext> next = _ => ValueTask.CompletedTask;
+
+        // 构建责任链，从尾部向前构建
+        for (var i = _pipes.Count - 1; i >= 0; i--)
+        {
+            next = _pipes[i].Invoke(next);
+        }
+
+        // 返回责任链第一个pipe
+        return next;
+    }
+}

--- a/test/Luck.UnitTest/Pipeline/Domain.cs
+++ b/test/Luck.UnitTest/Pipeline/Domain.cs
@@ -1,0 +1,8 @@
+namespace Luck.UnitTest.Pipeline;
+
+public class Domain
+{
+    public string SerialNo { get; set; } = default!;
+
+    public int Type { get; set; } = default!;
+}

--- a/test/Luck.UnitTest/Pipeline/HandlerDelegate.cs
+++ b/test/Luck.UnitTest/Pipeline/HandlerDelegate.cs
@@ -1,0 +1,5 @@
+using System.Threading.Tasks;
+
+namespace Luck.UnitTest.Pipeline;
+
+public delegate ValueTask HandlerDelegate<in TContext>(TContext context) where TContext : class;

--- a/test/Luck.UnitTest/Pipeline/IPipe.cs
+++ b/test/Luck.UnitTest/Pipeline/IPipe.cs
@@ -1,0 +1,8 @@
+using System.Threading.Tasks;
+
+namespace Luck.UnitTest.Pipeline;
+
+public interface IPipe<TContext> where TContext : class
+{
+    ValueTask InvokeAsync(TContext context, HandlerDelegate<TContext> next);
+}

--- a/test/Luck.UnitTest/Pipeline/IPipelineBuilder.cs
+++ b/test/Luck.UnitTest/Pipeline/IPipelineBuilder.cs
@@ -1,0 +1,9 @@
+namespace Luck.UnitTest.Pipeline;
+
+public interface IPipelineBuilder<TContext> where TContext : class
+{
+
+    IPipelineBuilder<TContext> UsePipe(IPipe<TContext> pipe);
+    
+    HandlerDelegate<TContext> Build();
+}

--- a/test/Luck.UnitTest/Pipeline/OrderInfo.cs
+++ b/test/Luck.UnitTest/Pipeline/OrderInfo.cs
@@ -1,0 +1,8 @@
+namespace Luck.UnitTest.Pipeline;
+
+public class OrderInfo
+{
+    public string SerialNo { get; set; } = default!;
+
+    public int Type { get; set; } = default!;
+}

--- a/test/Luck.UnitTest/Pipeline/PipeBase.cs
+++ b/test/Luck.UnitTest/Pipeline/PipeBase.cs
@@ -1,0 +1,23 @@
+using System.Threading.Tasks;
+
+namespace Luck.UnitTest.Pipeline;
+
+public abstract class PipeBase<TContext> : IPipe<TContext> where TContext : class
+{
+    public async ValueTask InvokeAsync(TContext context, HandlerDelegate<TContext> next)
+    {
+        // 当前核心流程
+        var valueTask1 = InvokeCoreAsync(context);
+        // 不能直接判断完成，内部抛异常时，不await，外层捕获不到异常
+        // if (!valueTask1.IsCompleted)
+        // {
+        await valueTask1;
+        // }
+
+        // 保证调用下一步
+        var valueTask2 = next(context);
+        await valueTask2;
+    }
+
+    protected abstract ValueTask InvokeCoreAsync(TContext context);
+}

--- a/test/Luck.UnitTest/Pipeline/PipeDelegate.cs
+++ b/test/Luck.UnitTest/Pipeline/PipeDelegate.cs
@@ -1,0 +1,3 @@
+namespace Luck.UnitTest.Pipeline;
+
+public delegate HandlerDelegate<TContext> PipeDelegate<TContext>(HandlerDelegate<TContext> next) where TContext : class;

--- a/test/Luck.UnitTest/Pipeline/PipelineBuilders.cs
+++ b/test/Luck.UnitTest/Pipeline/PipelineBuilders.cs
@@ -1,0 +1,7 @@
+namespace Luck.UnitTest.Pipeline;
+
+public class PipelineBuilders
+{
+    public static IPipelineBuilder<TContext> CreateBuilder<TContext>() where TContext : class
+        => new DefaultPipelineBuilder<TContext>();
+}

--- a/test/Luck.UnitTest/Pipeline/Response.cs
+++ b/test/Luck.UnitTest/Pipeline/Response.cs
@@ -1,0 +1,6 @@
+namespace Luck.UnitTest.Pipeline;
+
+public class Response
+{
+    public bool Success { get; set; }
+}

--- a/test/Luck.UnitTest/Pipeline/TestPipeLine.cs
+++ b/test/Luck.UnitTest/Pipeline/TestPipeLine.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Luck.UnitTest.Pipeline;
+
+public class TestPipeLine
+{
+    [Fact]
+    public async Task New_Pipeline_Test()
+    {
+        var test = new TrainPaySuccessPipeline();
+        var test1 = new TrainPaySuccessGetPipeline();
+        var trainPaySuccessContext = new TrainPaySuccessContext()
+        {
+            Request = new OrderInfo()
+            {
+                SerialNo = "A00001",
+                Type = 2,
+            },
+            Response = new Response()
+            {
+                Success = false,
+            }
+        };
+        var pipelineBuilder = PipelineBuilders.CreateBuilder<TrainPaySuccessContext>();
+        pipelineBuilder.UsePipe(test);
+        pipelineBuilder.UsePipe(test1);
+        
+        await pipelineBuilder.Build()(trainPaySuccessContext);
+        Assert.True(trainPaySuccessContext.Response.Success);
+        Assert.True(trainPaySuccessContext.Domain.SerialNo == trainPaySuccessContext.Request.SerialNo);
+    }
+}

--- a/test/Luck.UnitTest/Pipeline/TrainPaySuccessContext.cs
+++ b/test/Luck.UnitTest/Pipeline/TrainPaySuccessContext.cs
@@ -1,0 +1,7 @@
+namespace Luck.UnitTest.Pipeline;
+
+public class TrainPaySuccessContext : ContextBase<OrderInfo, Response>
+{
+
+    public Domain Domain { get; set; } = default!;
+}

--- a/test/Luck.UnitTest/Pipeline/TrainPaySuccessPipeline.cs
+++ b/test/Luck.UnitTest/Pipeline/TrainPaySuccessPipeline.cs
@@ -1,0 +1,28 @@
+using System.Threading.Tasks;
+
+namespace Luck.UnitTest.Pipeline;
+
+public class TrainPaySuccessPipeline : PipeBase<TrainPaySuccessContext>
+{
+    protected override async ValueTask InvokeCoreAsync(TrainPaySuccessContext context)
+    {
+        await Task.CompletedTask;
+        context.Response.Success = true;
+    }
+}
+
+
+public class TrainPaySuccessGetPipeline : PipeBase<TrainPaySuccessContext>
+{
+    protected override async ValueTask InvokeCoreAsync(TrainPaySuccessContext context)
+    {
+        await Task.CompletedTask;
+
+        context.Domain = new Domain()
+        {
+            SerialNo = context.Request.SerialNo,
+        };
+        
+        context.Response.Success = true;
+    }
+}


### PR DESCRIPTION
+ ## change 2.0.4 version 
  + ### add
    + **1、Luck.EntityFrameworkCore.MemoryDataBase**
  + ### update
    + **1、Luck.Framework支持Net7.0和8.0**
    + **2、Luck.DDD.Domain支持Net7.0和8.0**
    + **3、Luck.AspNetCore支持Net7.0和8.0**
    ```c#
        <ItemGroup Condition="$(TargetFramework) == 'net6.0'">
          <FrameworkReference Include="Microsoft.AspNetCore.App" />
        </ItemGroup>
        <ItemGroup Condition="$(TargetFramework) == 'net7.0'">
            <FrameworkReference Include="Microsoft.AspNetCore.App" />
        </ItemGroup>
        <ItemGroup Condition="$(TargetFramework) == 'net8.0'">
            <FrameworkReference Include="Microsoft.AspNetCore.App" />
        </ItemGroup>
      ```
    + **4、Luck.AppModule支持Net7.0和8.0**
    + **5、Luck.AutoDependencyInjection支持Net7.0和8.0；移动模块化扩展方法到Luck.AutoDependencyInjection类库**
    + **6、Luck.MongoDB支持Net7.0和8.0**
    + **7、Luck.EntityFrameworkCore支持EFCore7.0he 8.0**
    + **8、Luck.EntityFrameworkCore.MySQL；升级6.0的nuget包版本**
    + **9、Luck.EntityFrameworkCore.PostGreSQL支持Net7.0和8.0；升级6.0的nuget包版本**
    + **10、Luck.Dapper支持Net7.0和8.0;**
    + **11、Luck.Dapper.ClickHouse支持Net7.0和8.0**
    + **12、Luck.EventBus.RabbitMQ支持Net7.0和8.0；升级Polly和RabbitMQ.Client版本；通过一下代码导入需要Hosting等组件，不在单独引入包**
    ```c#
        <ItemGroup Condition="$(TargetFramework) == 'net6.0'">
          <FrameworkReference Include="Microsoft.AspNetCore.App" />
        </ItemGroup>
        <ItemGroup Condition="$(TargetFramework) == 'net7.0'">
            <FrameworkReference Include="Microsoft.AspNetCore.App" />
        </ItemGroup>
        <ItemGroup Condition="$(TargetFramework) == 'net8.0'">
            <FrameworkReference Include="Microsoft.AspNetCore.App" />
        </ItemGroup>
      ```
    + **13、Luck.Redis.StackExchange支持Net7.0和8.0；升级6.0的nuget包版本**